### PR TITLE
Add checks from gometalinter

### DIFF
--- a/.ci/go-lint.sh
+++ b/.ci/go-lint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ ! $(command -v gometalinter) ]
+then
+	go get github.com/alecthomas/gometalinter
+	gometalinter --install --vendor
+fi
+
+gometalinter \
+	--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
+	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
+	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
+	--disable=aligncheck \
+	--disable=gotype \
+	--disable=gas \
+	--disable=vetshadow \
+	--cyclo-over=15 \
+	--tests \
+	--deadline=120s \
+	--vendor \
+	./...

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ TIMEOUT ?= 5
 functional:
 	ginkgo ./functional/ -- -runtime "${RUNTIME}" -proxy "${PROXY}" -shim "${SHIM}" -timeout ${TIMEOUT}
 
+check:
+	.ci/go-lint.sh
+
 all: functional
 
-.PHONY: functional
+.PHONY: functional check

--- a/command.go
+++ b/command.go
@@ -76,7 +76,9 @@ func NewCommand(path string, args ...string) *Command {
 // Run runs a command returning its exit code
 func (c *Command) Run() int {
 	LogIfFail("Running command '%s %s'\n", c.cmd.Path, c.cmd.Args)
-	c.cmd.Start()
+	if err := c.cmd.Start(); err != nil {
+		LogIfFail("could no start command: %v\n", err)
+	}
 
 	done := make(chan error)
 	go func() { done <- c.cmd.Wait() }()
@@ -89,7 +91,7 @@ func (c *Command) Run() int {
 	select {
 	case <-timeout:
 		LogIfFail("Killing process timeout reached '%d' seconds\n", c.Timeout)
-		c.cmd.Process.Kill()
+		_ = c.cmd.Process.Kill()
 		return -1
 
 	case err := <-done:

--- a/command.go
+++ b/command.go
@@ -17,12 +17,9 @@ package tests
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"os/exec"
 	"syscall"
 	"time"
-
-	. "github.com/onsi/ginkgo"
 )
 
 // Runtime is the path of Clear Containers Runtime
@@ -78,7 +75,7 @@ func NewCommand(path string, args ...string) *Command {
 
 // Run runs a command returning its exit code
 func (c *Command) Run() int {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("Running command '%s %s'\n", c.cmd.Path, c.cmd.Args)))
+	LogIfFail("Running command '%s %s'\n", c.cmd.Path, c.cmd.Args)
 	c.cmd.Start()
 
 	done := make(chan error)
@@ -91,17 +88,17 @@ func (c *Command) Run() int {
 
 	select {
 	case <-timeout:
-		GinkgoWriter.Write([]byte(fmt.Sprintf("Killing process timeout reached '%d' seconds\n", c.Timeout)))
+		LogIfFail("Killing process timeout reached '%d' seconds\n", c.Timeout)
 		c.cmd.Process.Kill()
 		return -1
 
 	case err := <-done:
 		if err != nil {
-			GinkgoWriter.Write([]byte(fmt.Sprintf("command failed error '%s'\n", err)))
+			LogIfFail("command failed error '%s'\n", err)
 		}
 		exitCode := c.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 		if exitCode != c.ExitCode {
-			GinkgoWriter.Write([]byte(fmt.Sprintf("Exit code '%d' does not match with expected exit code '%d'\n", exitCode, c.ExitCode)))
+			LogIfFail("Exit code '%d' does not match with expected exit code '%d'\n", exitCode, c.ExitCode)
 		}
 		return exitCode
 	}

--- a/log.go
+++ b/log.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+)
+
+// LogIfFail will output the message online if the test fails. This can be used
+// for information that would be useful to debug a failure.
+func LogIfFail(format string, args ...interface{}) {
+	str := fmt.Sprintf(format, args...)
+	_, _ = ginkgo.GinkgoWriter.Write([]byte(str))
+}


### PR DESCRIPTION
A few small fixes were needed to make gometalinter pass. `make check` can now be used to check the tests code base itself.