### PR TITLE
checkcommits: Use proper grammar rules in verbose message.

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -465,8 +465,13 @@ func preChecks(config *CommitConfig, commit, branch string) error {
 	}
 
 	if verbose {
-		fmt.Printf("Found %d commits between commit %v and branch %v\n",
-			len(commits), commit, branch)
+		l := len(commits)
+		extra := ""
+		if l != 1 {
+			extra = "s"
+		}
+		fmt.Printf("Found %d commit%s between commit %v and branch %v\n",
+			l, extra, commit, branch)
 	}
 
 	return checkCommits(config, commits)


### PR DESCRIPTION
"Found 1 commits" is just awful.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>