### PR TITLE
ci: Don't install CC kernel from the rpm repository

### DIFF
--- a/.ci/install_cc_env_ubuntu.sh
+++ b/.ci/install_cc_env_ubuntu.sh
@@ -29,9 +29,6 @@ chronic sudo apt-get install -y rpm2cpio
 echo "Update apt repositories"
 chronic sudo apt-get update
 
-echo "Install linux-container kernel"
-chronic sudo apt-get install -y --force-yes linux-container
-
 echo "Install qemu-lite binary"
 chronic sudo apt-get install -y --force-yes qemu-lite
 


### PR DESCRIPTION
Note: I can't really test this as CI isn't activated on this repo and I don't have anything practical to test it.

We're downloading a specific kernel later on, so no need to download the
kernel package.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>