### PR TITLE
Standalone clear image & kernel install scripts

### DIFF
--- a/.ci/install_cc_env_ubuntu.sh
+++ b/.ci/install_cc_env_ubuntu.sh
@@ -29,9 +29,6 @@ chronic sudo apt-get install -y rpm2cpio
 echo "Update apt repositories"
 chronic sudo apt-get update
 
-echo "Install linux-container kernel"
-chronic sudo apt-get install -y --force-yes linux-container
-
 echo "Install qemu-lite binary"
 chronic sudo apt-get install -y --force-yes qemu-lite
 

--- a/.ci/install_cc_env_ubuntu.sh
+++ b/.ci/install_cc_env_ubuntu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
+#
 # Copyright (c) 2017 Intel Corporation
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 set -e
 

--- a/.ci/install_cc_env_ubuntu.sh
+++ b/.ci/install_cc_env_ubuntu.sh
@@ -16,6 +16,8 @@
 
 set -e
 
+cidir=$(dirname "$0")
+
 echo "Add clear containers sources to apt list"
 sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.1/xUbuntu_16.10/ /' >> /etc/apt/sources.list.d/cc-oci-runtime.list"
 
@@ -52,15 +54,10 @@ echo -e "Create symbolic link ${cc_img_path}/${cc_img_link_name}"
 sudo ln -fs ${cc_img_path}/clear-${latest_version}-containers.img ${cc_img_path}/${cc_img_link_name}
 
 bug_url="https://github.com/clearcontainers/runtime/issues/91"
+kernel_clear_release=12760
 kernel_version="4.5-50"
-cc_kernel_link_name="vmlinux.container"
 echo -e "\nWARNING:"
 echo "WARNING: Using backlevel kernel version ${kernel_version} due to bug ${bug_url}"
 echo -e "WARNING:\n"
-echo -e "Install clear containers kernel ${kernel_version}"
-curl -LO "https://download.clearlinux.org/releases/12760/clear/x86_64/os/Packages/linux-container-${kernel_version}.x86_64.rpm"
-rpm2cpio linux-container-${kernel_version}.x86_64.rpm | cpio -ivdm
-sudo install --owner root --group root --mode 0755 .${cc_img_path}/vmlinux-${kernel_version}.container ${cc_img_path}
 
-echo -e "Create symbolic link ${cc_img_path}/${cc_kernel_link_name}"
-sudo ln -fs ${cc_img_path}/vmlinux-${kernel_version}.container ${cc_img_path}/${cc_kernel_link_name}
+"./$cidir/install_clear_kernel.sh" ${kernel_clear_release} ${kernel_version} "${cc_img_path}"

--- a/.ci/install_cc_env_ubuntu.sh
+++ b/.ci/install_cc_env_ubuntu.sh
@@ -33,25 +33,10 @@ chronic sudo apt-get update
 echo "Install qemu-lite binary"
 chronic sudo apt-get install -y --force-yes qemu-lite
 
-echo "Download clear containers image"
-latest_version=$(curl -sL https://download.clearlinux.org/latest)
-curl -LO "https://download.clearlinux.org/current/clear-${latest_version}-containers.img.xz"
-
-echo "Validate clear containers image checksum"
-curl -LO "https://download.clearlinux.org/current/clear-${latest_version}-containers.img.xz-SHA512SUMS"
-sha512sum -c clear-${latest_version}-containers.img.xz-SHA512SUMS
-
-echo "Extract clear containers image"
-unxz clear-${latest_version}-containers.img.xz
-
+clear_release=$(curl -sL https://download.clearlinux.org/latest)
 cc_img_path="/usr/share/clear-containers"
-cc_img_link_name="clear-containers.img"
-sudo mkdir -p ${cc_img_path}
-echo "Install clear containers image"
-sudo install --owner root --group root --mode 0755 clear-${latest_version}-containers.img ${cc_img_path}
 
-echo -e "Create symbolic link ${cc_img_path}/${cc_img_link_name}"
-sudo ln -fs ${cc_img_path}/clear-${latest_version}-containers.img ${cc_img_path}/${cc_img_link_name}
+"./$cidir/install_clear_image.sh" ${clear_release} "${cc_img_path}"
 
 bug_url="https://github.com/clearcontainers/runtime/issues/91"
 kernel_clear_release=12760

--- a/.ci/install_clear_image.sh
+++ b/.ci/install_clear_image.sh
@@ -1,0 +1,47 @@
+
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 CLEAR_RELEASE PATH"
+    echo "       Install the clear rootfs image from clear CLEAR_RELEASE in PATH."
+    exit 1
+fi
+
+clear_release="$1"
+install_path="$2"
+image=clear-${clear_release}-containers.img
+cc_img_link_name="clear-containers.img"
+base_url="https://download.clearlinux.org/releases/${clear_release}/clear"
+
+echo "Download clear containers image"
+curl -LO "${base_url}/${image}.xz"
+
+echo "Validate clear containers image checksum"
+curl -LO "${base_url}/${image}.xz-SHA512SUMS"
+sha512sum -c ${image}.xz-SHA512SUMS
+
+echo "Extract clear containers image"
+unxz ${image}.xz
+
+sudo mkdir -p ${install_path}
+echo "Install clear containers image"
+sudo install -D --owner root --group root --mode 0755 ${image} ${install_path}/${image}
+
+echo -e "Create symbolic link ${install_path}/${cc_img_link_name}"
+sudo ln -fs ${install_path}/${image} ${install_path}/${cc_img_link_name}

--- a/.ci/install_clear_image.sh
+++ b/.ci/install_clear_image.sh
@@ -45,3 +45,6 @@ sudo install -D --owner root --group root --mode 0755 ${image} ${install_path}/$
 
 echo -e "Create symbolic link ${install_path}/${cc_img_link_name}"
 sudo ln -fs ${install_path}/${image} ${install_path}/${cc_img_link_name}
+
+# clean up
+rm -f ${image} ${image}.xz-SHA512SUMS

--- a/.ci/install_clear_kernel.sh
+++ b/.ci/install_clear_kernel.sh
@@ -37,3 +37,10 @@ sudo install -D --owner root --group root --mode 0700 .${clear_install_path}/${k
 
 echo -e "Create symbolic link ${install_path}/${cc_kernel_link_name}"
 sudo ln -fs ${install_path}/${kernel} ${install_path}/${cc_kernel_link_name}
+
+# cleanup
+rm -f linux-container-${kernel_version}.x86_64.rpm
+# be careful here, we don't want to rm something silly, note the leading .
+rm -r .${clear_install_path}
+rmdir ./usr/share
+rmdir ./usr

--- a/.ci/install_clear_kernel.sh
+++ b/.ci/install_clear_kernel.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 CLEAR_RELEASE KERNEL_VERSION PATH"
+    echo "       Install the clear kernel image KERNEL_VERSION from clear CLEAR_RELEASE in PATH."
+    exit 1
+fi
+
+clear_release="$1"
+kernel_version="$2"
+cc_img_path="$3"
+kernel=vmlinux-${kernel_version}.container
+cc_kernel_link_name="vmlinux.container"
+
+echo -e "Install clear containers kernel ${kernel_version}"
+
+curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/linux-container-${kernel_version}.x86_64.rpm"
+rpm2cpio linux-container-${kernel_version}.x86_64.rpm | cpio -ivdm
+sudo install -D --owner root --group root --mode 0755 .${cc_img_path}/${kernel} ${cc_img_path}/${kernel}
+
+echo -e "Create symbolic link ${cc_img_path}/${cc_kernel_link_name}"
+sudo ln -fs ${cc_img_path}/${kernel} ${cc_img_path}/${cc_kernel_link_name}

--- a/.ci/install_clear_kernel.sh
+++ b/.ci/install_clear_kernel.sh
@@ -33,7 +33,7 @@ echo -e "Install clear containers kernel ${kernel_version}"
 
 curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/linux-container-${kernel_version}.x86_64.rpm"
 rpm2cpio linux-container-${kernel_version}.x86_64.rpm | cpio -ivdm
-sudo install -D --owner root --group root --mode 0755 .${clear_install_path}/${kernel} ${install_path}/${kernel}
+sudo install -D --owner root --group root --mode 0700 .${clear_install_path}/${kernel} ${install_path}/${kernel}
 
 echo -e "Create symbolic link ${install_path}/${cc_kernel_link_name}"
 sudo ln -fs ${install_path}/${kernel} ${install_path}/${cc_kernel_link_name}

--- a/.ci/install_clear_kernel.sh
+++ b/.ci/install_clear_kernel.sh
@@ -24,7 +24,8 @@ fi
 
 clear_release="$1"
 kernel_version="$2"
-cc_img_path="$3"
+install_path="$3"
+clear_install_path="/usr/share/clear-containers"
 kernel=vmlinux-${kernel_version}.container
 cc_kernel_link_name="vmlinux.container"
 
@@ -32,7 +33,7 @@ echo -e "Install clear containers kernel ${kernel_version}"
 
 curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/linux-container-${kernel_version}.x86_64.rpm"
 rpm2cpio linux-container-${kernel_version}.x86_64.rpm | cpio -ivdm
-sudo install -D --owner root --group root --mode 0755 .${cc_img_path}/${kernel} ${cc_img_path}/${kernel}
+sudo install -D --owner root --group root --mode 0755 .${clear_install_path}/${kernel} ${install_path}/${kernel}
 
-echo -e "Create symbolic link ${cc_img_path}/${cc_kernel_link_name}"
-sudo ln -fs ${cc_img_path}/${kernel} ${cc_img_path}/${cc_kernel_link_name}
+echo -e "Create symbolic link ${install_path}/${cc_kernel_link_name}"
+sudo ln -fs ${install_path}/${kernel} ${install_path}/${cc_kernel_link_name}


### PR DESCRIPTION
Note: I couldn't test this in CI, and these are fairly intrusive changes. At least the 2 individual scripts do work locally.

I decided I wouldn't install clear kernel and images by hand any longer so I split two scripts out of the ci setup script.

```
# ./.ci/install_clear_kernel.sh 14700 4.9.4-57 /usr/share/clear-containers
# ./.ci/install_clear_image.sh 14700 /usr/share/clear-containers
```