### PR TITLE
checkcommits: Fix for running under SemaphoreCI.

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -400,7 +400,10 @@ func detectCIEnvironment() (commit, dstBranch, srcBranch string) {
 		// refers to the name of the current branch being built.
 		if os.Getenv("PULL_REQUEST_NUMBER") != "" {
 			srcBranch = dstBranch
-			dstBranch = defaultBranch
+
+			// Oddly, a git checkout for a PR under Semaphore *only*
+			// contains that branch: master doesn't exist.
+			dstBranch = "origin"
 		}
 	}
 


### PR DESCRIPTION
The git checkout on SemaphoreCI systems doesn't include
a "master" branch, so use "origin" instead.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>