### PR TITLE
checkcommits: Run tests before installing binary.

### DIFF
--- a/cmd/checkcommits/Makefile
+++ b/cmd/checkcommits/Makefile
@@ -8,8 +8,8 @@ COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO
 default: $(TARGET)
 
 $(TARGET): $(SOURCES)
+	go test .
 	go install -ldflags "-X main.appCommit=${COMMIT} -X main.appVersion=${VERSION}" .
-	go test
 
 clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
The tests should be run before the binary is installed.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>