### PR TITLE
checkcommits: Fix build instructions.

### DIFF
--- a/cmd/checkcommits/README.md
+++ b/cmd/checkcommits/README.md
@@ -70,7 +70,9 @@ $ ./checkcommits -h
 ### Download and Build
 
 ```
-$ go get github.com/clearcontainers/tests/cmd/checkcommits
+$ repo="github.com/clearcontainers/tests/cmd/checkcommits"
+$ go get -d "$repo"
+$ (cd "$GOPATH/src/$repo" && make)
 ```
 
 ### Basic use


### PR DESCRIPTION
A simple "go get" isn't sufficient: checkcommits needs to be
built using make to ensure the version and commit details are
embedded in the binary.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>