### PR TITLE
build: Fix the ginkgo build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TIMEOUT ?= 5
 
 ginkgo:
 	ln -sf . vendor/src
-	GOPATH=$(PWD)/vendor/src go build ./vendor/github.com/onsi/ginkgo/ginkgo
+	GOPATH=$(PWD)/vendor go build ./vendor/github.com/onsi/ginkgo/ginkgo
 	unlink vendor/src
 
 functional: ginkgo


### PR DESCRIPTION
"$GOPATH" was being incorrectly specified with a trailing "/src".

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>