### PR TITLE
build: Add license headers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Path of Clear Containers Runtime
 CC_RUNTIME ?= cc-runtime
 

--- a/cmd/checkcommits/Makefile
+++ b/cmd/checkcommits/Makefile
@@ -1,3 +1,17 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 TARGET = checkcommits
 SOURCES = $(shell find . 2>&1 | grep -E '.*\.go$$')
 


### PR DESCRIPTION
Added missing license headers to the Makefiles.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>