### PR TITLE
ci: fix proxy upstart service

### DIFF
--- a/.ci/upstart-services/cc-proxy.conf
+++ b/.ci/upstart-services/cc-proxy.conf
@@ -6,4 +6,4 @@ start on runlevel [2345]
 # stop on shutdown/halt, single-user mode and reboot
 stop on runlevel [016]
 
-exec /usr/libexec/clear-containers/cc-proxy -v 3
+exec /usr/libexec/clear-containers/cc-proxy -log debug


### PR DESCRIPTION
cc-proxy has replaced the option '-v' with '-log' to specify the log
level therefore this patch updates the upstart service used in the CI

fixes #55

Signed-off-by: Julio Montes <julio.montes@intel.com>