### PR TITLE
functional: run container without pid file

### DIFF
--- a/functional/run_test.go
+++ b/functional/run_test.go
@@ -106,8 +106,7 @@ var _ = Describe("run", func() {
 		},
 		withoutOption("--bundle", shouldFail),
 		withoutOption("-b", shouldFail),
-		// FIXME: uncomment once issue https://github.com/clearcontainers/runtime/issues/212 is fixed
-		// withoutOption("--pid-file", shouldFail),
+		withoutOption("--pid-file", shouldNotFail),
 		withoutOption("--console", shouldNotFail),
 	)
 })


### PR DESCRIPTION
add test to check if a container can run without a pid file

fixes #62

Signed-off-by: Julio Montes <julio.montes@intel.com>