### PR TITLE
Fix semaphore CI by updating CRI-O tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ TIMEOUT ?= 5
 CRIO_REPO_PATH="${GOPATH}/src/github.com/kubernetes-incubator/cri-o"
 crio:
 	bash .ci/install_bats.sh
-	ln -sf $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test
+	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
 	cd ${CRIO_REPO_PATH} && \
-	make localintegration RUNTIME=${CC_RUNTIME} TESTFLAGS="crio.bats"
+	RUNTIME=${CC_RUNTIME} ./test/test_runner.sh crio.bats
 
 ginkgo:
 	ln -sf . vendor/src

--- a/integration/cri-o/crio.bats
+++ b/integration/cri-o/crio.bats
@@ -219,3 +219,254 @@ function teardown() {
 	cleanup_pods
 	stop_crio
 }
+
+@test "ctr list filtering" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json --name pod1
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod1_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod1_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr1_id="$output"
+	run crioctl ctr start --id "$ctr1_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json --name pod2
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod2_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod2_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr2_id="$output"
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json --name pod3
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod3_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod3_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr3_id="$output"
+	run crioctl ctr start --id "$ctr3_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl ctr stop --id "$ctr3_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl ctr list --id "$ctr1_id" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	run crioctl ctr list --id "${ctr1_id:0:4}" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	run crioctl ctr list --id "$ctr2_id" --pod "$pod2_id" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr2_id"  ]]
+	run crioctl ctr list --id "$ctr2_id" --pod "$pod3_id" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" == "" ]]
+	run crioctl ctr list --state created --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr2_id"  ]]
+	run crioctl ctr list --state running --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	run crioctl ctr list --state stopped --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr3_id"  ]]
+	run crioctl ctr list --pod "$pod1_id" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	run crioctl ctr list --pod "$pod2_id" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr2_id"  ]]
+	run crioctl ctr list --pod "$pod3_id" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr3_id"  ]]
+	run crioctl pod remove --id "$pod1_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl pod remove --id "$pod2_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl pod remove --id "$pod3_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "ctr list label filtering" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id" --name ctr1 --label "a=b" --label "c=d" --label "e=f"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr1_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id" --name ctr2 --label "a=b" --label "c=d"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr2_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id" --name ctr3 --label "a=b"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr3_id="$output"
+	run crioctl ctr list --label "tier=backend" --label "a=b" --label "c=d" --label "e=f" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	run crioctl ctr list --label "tier=frontend" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" == "" ]]
+	run crioctl ctr list --label "a=b" --label "c=d" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	[[ "$output" =~ "$ctr2_id"  ]]
+	run crioctl ctr list --label "a=b" --quiet
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" != "" ]]
+	[[ "$output" =~ "$ctr1_id"  ]]
+	[[ "$output" =~ "$ctr2_id"  ]]
+	[[ "$output" =~ "$ctr3_id"  ]]
+	run crioctl pod remove --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "ctr metadata in list & status" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_config.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+
+	run crioctl ctr list --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# TODO: expected value should not hard coded here
+	[[ "$output" =~ "Name: container1" ]]
+	[[ "$output" =~ "Attempt: 1" ]]
+
+	run crioctl ctr status --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	# TODO: expected value should not hard coded here
+	[[ "$output" =~ "Name: container1" ]]
+	[[ "$output" =~ "Attempt: 1" ]]
+
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "ctr execsync conflicting with conmon flags parsing" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crioctl ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl ctr execsync --id "$ctr_id" sh -c "echo hello world"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "hello world" ]]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "ctr execsync" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crioctl ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl ctr execsync --id "$ctr_id" echo HELLO
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "HELLO" ]]
+	run crioctl ctr execsync --id "$ctr_id" --timeout 1 sleep 10
+	echo "$output"
+	[[ "$output" =~ "command timed out" ]]
+	run crioctl pod remove --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "ctr device add" {
+	start_crio
+	run crioctl pod run --config "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+	run crioctl ctr create --config "$TESTDATA"/container_redis_device.json --pod "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crioctl ctr start --id "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crioctl ctr execsync --id "$ctr_id" ls /dev/mynull
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "/dev/mynull" ]]
+	run crioctl pod remove --id "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}


### PR DESCRIPTION
This PR fixes https://github.com/clearcontainers/runtime/issues/215 by calling directly into the CRI-O test suite instead of "make localintegration" which was rebuilding everything from scratch.
Moreover, it adds more CRI-O bats.