### PR TITLE
Makefile: Fix Semaphore CI failing because of CRI-O tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ TIMEOUT ?= 5
 CRIO_REPO_PATH="${GOPATH}/src/github.com/kubernetes-incubator/cri-o"
 crio:
 	bash .ci/install_bats.sh
-	ln -sf $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test
+	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
 	cd ${CRIO_REPO_PATH} && \
-	make localintegration RUNTIME=${CC_RUNTIME} TESTFLAGS="crio.bats"
+	RUNTIME=${CC_RUNTIME} ./test/test_runner.sh crio.bats
 
 ginkgo:
 	ln -sf . vendor/src


### PR DESCRIPTION
Because we get Semaphore CI hanging sometimes when trying to build everything from a "make localintegration" for the testing of CRI-O, this patch only calls into the test itself, without the need for rebuilding everything.