### PR TITLE
CI: Override runtime build defaults.

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -21,15 +21,25 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 
-runtime_dir="${GOPATH}/src/github.com/clearcontainers/runtime"
-runtime_config_path="/etc/clear-containers"
-runtime_config_file="configuration.toml"
+# Modify the runtimes build-time defaults
 
+# The OBS packages install qemu-lite here
+export QEMUBINDIR=/usr/bin
+
+# The runtimes config file should live here
+export SYSCONFDIR=/etc
+
+# Artifacts (kernel + image) live below here
+export SHAREDIR=/usr/share
+
+runtime_dir="${GOPATH}/src/github.com/clearcontainers/runtime"
+runtime_config_path="${SYSCONFDIR}/clear-containers/configuration.toml"
+
+# Note: This will also install the config file.
 clone_build_and_install "github.com/clearcontainers/runtime"
 
-echo "Install runtime ${runtime_config_file} to ${runtime_config_path}"
-sudo mkdir -p ${runtime_config_path}
-sed 's/^#\(\[runtime\]\|global_log_path =\)/\1/g' ${runtime_dir}/config/${runtime_config_file} | sudo tee ${runtime_config_path}/${runtime_config_file}
+echo "Enabling global logging for runtime in file ${runtime_config_path}"
+sudo sed -i -e 's/^#\(\[runtime\]\|global_log_path =\)/\1/g' "${runtime_config_path}"
 
 echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to Semaphore CI updates."
 sudo mkdir -p /etc/default

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -35,7 +35,7 @@ function clone_and_build() {
 		echo "Run autogen.sh to generate Makefile"
 		bash -f autogen.sh
 	fi
-	make ${make_target}
+	make -e ${make_target}
 
 	popd
 }
@@ -44,6 +44,6 @@ function clone_build_and_install() {
 	clone_and_build $1 $2
 	pushd "${GOPATH}/src/${1}"
 	echo "Install repository ${1}"
-	sudo make install
+	sudo -E make -e install
 	popd
 }


### PR DESCRIPTION
Install the runtime with modified defaults to ensure it uses the
expected paths. This requires a few variables to be set that will
override the defaults in the runtimes Makefile along with running
"make -e" to tell make to only set variables if they are not
already set.

This change is required to support:

- https://github.com/clearcontainers/runtime/pull/225.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>