### PR TITLE
Disable crio tests from make check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ ginkgo:
 functional: ginkgo
 	./ginkgo functional/ -- -runtime ${CC_RUNTIME} -timeout ${TIMEOUT}
 
-check:	functional crio
+# Add crio tests here when https://github.com/clearcontainers/runtime/issues/215
+# is fixed.
+check:	functional
 
 all: functional checkcommits
 


### PR DESCRIPTION
Removes crio from 'make check', since the tests are
unstable. The tests should be re-added once
https://github.com/clearcontainers/runtime/issues/215
is fixed.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>