### PR TITLE
CI: Check if system supports Clear Containers.

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -47,6 +47,9 @@ runtime_config_path="${SYSCONFDIR}/clear-containers/configuration.toml"
 # Note: This will also install the config file.
 clone_build_and_install "github.com/clearcontainers/runtime"
 
+# Check system supports running Clear Containers
+cc-runtime cc-check
+
 echo "Enabling global logging for runtime in file ${runtime_config_path}"
 sudo sed -i -e 's/^#\(\[runtime\]\|global_log_path =\)/\1/g' "${runtime_config_path}"
 


### PR DESCRIPTION
After installing the runtime, run its "cc-check" command to ensure the
system is capable of running Clear Containers.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>