### PR TITLE
Makefile: Re-enable and fix CRI-O tests on Semaphore CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ crio:
 	bash .ci/install_bats.sh
 	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
 	cd ${CRIO_REPO_PATH} && \
-	RUNTIME=${CC_RUNTIME} ./test/test_runner.sh crio.bats
+	RUNTIME=${CC_RUNTIME} STORAGE_OPTS="--storage-driver=aufs" ./test/test_runner.sh crio.bats
 
 ginkgo:
 	ln -sf . vendor/src
@@ -35,7 +35,7 @@ functional: ginkgo
 
 # Add crio tests here when https://github.com/clearcontainers/runtime/issues/215
 # is fixed.
-check:	functional
+check: functional crio
 
 all: functional checkcommits
 


### PR DESCRIPTION
This patch re-enables the CRI-O tests because they are now fixed by the recent introduction of a specific variable into the bats. By setting the environment variable "CRI_STORAGE", we can now specify which storage driver we want to use.

In case of Semaphore, because it is running Ubuntu 14.04 on a 3.13 kernel, we have to set aufs as the storage driver, otherwise we get some issues using devicemapper.