### PR TITLE
20170626 nsenter builds

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -57,7 +57,7 @@ git clone git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
 pushd ${util_linux_path}
 ./autogen.sh
 ./configure --without-python --disable-all-programs --enable-nsenter
-make
+make nsenter
 sudo cp nsenter /usr/bin/
 popd
 rm -rf ${util_linux_path}

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -47,6 +47,9 @@ echo -e "WARNING:\n"
 
 "${cidir}/install_clear_kernel.sh" ${kernel_clear_release} ${kernel_version} "${cc_img_path}"
 
+echo "Install bison binary"
+chronic sudo apt-get install -y bison
+
 echo "Install nsenter"
 util_linux_path="util-linux"
 chronic sudo apt-get install -y autopoint


### PR DESCRIPTION
Running .`ci/setup.sh` locally failed to build and install nsenter - make a couple of, what should be benign to the CI systems, changes to fix this.