### PR TITLE
CI: enable crio builds when no go in root path

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -26,8 +26,8 @@ pushd $GOPATH/src/github.com/kubernetes-incubator/cri-o
 echo "Installing CRI-O"
 make install.tools
 make
-sudo make install
-sudo make install.config
+sudo -E PATH=$PATH sh -c "make install"
+sudo -E PATH=$PATH sh -c "make install.config"
 
 echo "Setup cc-runtime as the runtime to use"
 sudo sed -i.bak 's/\/usr\/bin\/runc/\/usr\/local\/bin\/cc-runtime/g' /etc/crio/crio.conf


### PR DESCRIPTION
On some Ubuntu systems go is not in the root path. Modify
the necessary install_crio.sh make lines sudo invocations to
utilise the go in the users space.

Fixes: #83

Signed-off-by: Graham Whaley <graham.whaley@intel.com>