### PR TITLE
fetchbranches: Fix typo

### DIFF
--- a/cmd/fetchbranches/CI.go
+++ b/cmd/fetchbranches/CI.go
@@ -18,7 +18,7 @@ package main
 
 import "os"
 
-// CI Continous Integration
+// CI Continuous Integration
 type CI interface {
 	// GetPR obtains the pull request number
 	GetPR() (*pr, error)


### PR DESCRIPTION
Fix a typo found by the go static checkers.

Fixes: #100

Signed-off-by: Graham Whaley <graham.whaley@intel.com>