### PR TITLE
metrics: Add PnP failure Report tool

### DIFF
--- a/cmd/emailreport/README.md
+++ b/cmd/emailreport/README.md
@@ -1,0 +1,15 @@
+# PnP failure Report tool
+
+This tool obtains metrics results from `checkmetrics` tool, and sends
+the results out via email.
+The configuration of SMTP server and `checkmetrics` tool arguments are
+given by a configuration file in TOML format, an example TOML configuration
+file is provided in the file `example.toml`
+
+WARNING: The password for the SMTP authentication will be in TOML
+configuration text plane file.
+
+# Usage
+```bash
+$ ./emailreport -f <conf.toml>
+```

--- a/cmd/emailreport/example.toml
+++ b/cmd/emailreport/example.toml
@@ -1,0 +1,26 @@
+# This section specifies information for
+# a SMTP server authentication as well as the
+# sender and receipts of the report email.
+# This is in order to send the obtained results
+# from checkmetrics to an email whitelist.
+# WARNING: The password for the SMTP authentication
+# will be in this text plane file.
+[mail]
+smtp = "myserver.smtp.com"
+port = "25"
+user = ""
+identity = ""
+password = ""
+from = "pnp@example.com"
+subject = "PnP failure Report <no-reply>"
+to = [ "maintainer@example.com",
+	"owner@example.com" ]
+cc = [ "contributor@example.com",
+	"developer@example.com" ]
+
+# This section specifies the arguments for
+# checkmetrics execution.
+[checkmetrics]
+cmd = "/usr/bin/checkmetrics"
+basefile = "/home/checkmetrics/conf.toml"
+metricsdir = "/home/checkmetrics/metricsdir"

--- a/cmd/emailreport/mail.go
+++ b/cmd/emailreport/mail.go
@@ -1,0 +1,85 @@
+/// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"net/smtp"
+	"strings"
+)
+
+// HeaderRFC822 provides a header as a
+// string according the RFC822 Standard for ARPA
+// Internet Text Messages.
+func HeaderRFC822(conf Configuration) string {
+	var header string
+
+	if conf.Mail.From == "" {
+		log.Fatal("Sender not specified")
+	}
+
+	if conf.Mail.Subject == "" {
+		log.Fatal("Message subject not specified")
+	}
+
+	if len(conf.Mail.To) == 0 {
+		log.Fatal("Receipts not specified")
+	}
+
+	header += "From: " + conf.Mail.From + "\n"
+	header += "To: " + strings.Join(conf.Mail.To, ",") + "\n"
+
+	if len(conf.Mail.Cc) > 0 {
+		header += "cc: " + strings.Join(conf.Mail.Cc, ",") + "\n"
+	}
+
+	header += "Subject: " + conf.Mail.Subject + "\n\n"
+
+	return header
+}
+
+// SendByEmail allows to send the result output of
+// checkmetrics execution to a whitelist of emails.
+// This list is described by a TOML configuration file.
+func SendByEmail(conf Configuration, body string) {
+	var header string
+	var msg string
+	var auth smtp.Auth
+	var server string
+
+	header = HeaderRFC822(conf)
+	msg = header + body
+
+	auth = smtp.PlainAuth(
+		conf.Mail.Id,       // SMTP identity
+		conf.Mail.User,     // SMTP user
+		conf.Mail.Password, // SMTP Server password
+		conf.Mail.Smtp,     // SMTP server address
+	)
+
+	server = conf.Mail.Smtp + ":" + conf.Mail.Port
+
+	// Connection/Authentication step
+	err := smtp.SendMail(
+		server,         // SMTP server:port
+		auth,           // SMTP authentication
+		conf.Mail.From, // Sender
+		conf.Mail.To,   // Receipts
+		[]byte(msg),    // Message
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/emailreport/mail_test.go
+++ b/cmd/emailreport/mail_test.go
@@ -1,0 +1,41 @@
+/// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestHeaderRFC822(t *testing.T) {
+	var conf Configuration
+	var header string
+	var expectHdr string
+
+	expectHdr += "From: pnp@example.com\n"
+	expectHdr += "To: maintainer@example.com,owner@example.com\n"
+	expectHdr += "cc: contributor@example.com,developer@example.com\n"
+	expectHdr += "Subject: PnP failure Report <no-reply>\n\n"
+
+	if _, err := toml.DecodeFile("example.toml", &conf); err != nil {
+		t.Fail()
+	}
+
+	header = HeaderRFC822(conf)
+	if header != expectHdr {
+		t.Fail()
+	}
+}

--- a/cmd/emailreport/main.go
+++ b/cmd/emailreport/main.go
@@ -1,0 +1,115 @@
+/// Copyight (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Configuration stores all necessary
+// information for checkmetrics execution
+// and sent output as a report by email.
+type Configuration struct {
+	Mail MailConf
+	Ck   Checkmetrics `toml:"checkmetrics"`
+}
+
+// MailConf stores the authentication
+// configuration for sending the report
+// by email. This information is parsed
+// from TOML input file.
+type MailConf struct {
+	Smtp     string   // SMTP server address
+	Port     string   // SMTP port
+	User     string   // SMTP user
+	Password string   // SMTP password
+	Id       string   // SMTP indetity
+	From     string   // Sender
+	Subject  string   // Email msg subject
+	To       []string // Receipts
+	Cc       []string // Msg copy
+}
+
+// Checkmetrics stores the arguments
+// for checkmetrics execution
+type Checkmetrics struct {
+	Cmd        string
+	Basefile   string
+	Metricsdir string
+}
+
+func main() {
+
+	var confFile string
+	var conf Configuration
+	var body string
+	var currentUid int
+	var ownerUid int
+
+	// Checkmetrics conf vars
+	var cmd string
+	var basefile string
+	var metricsdir string
+
+	flag.StringVar(&confFile, "f", "", "Configuration file")
+	flag.Parse()
+
+	// Get info about file
+	fileinfo, err := os.Stat(confFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Owner verification
+	currentUid = os.Geteuid()
+	fStat := fileinfo.Sys().(*syscall.Stat_t)
+	ownerUid = int(fStat.Uid)
+
+	if currentUid != ownerUid {
+		log.Fatal(currentUid,
+			" is not the owner of ", confFile,
+			" uid: ", ownerUid)
+	}
+
+	// Parsing TOML configuration file
+	if _, err := toml.DecodeFile(confFile, &conf); err != nil {
+		log.Fatal(err)
+	}
+
+	// Set checkmetrics configuration
+	cmd = conf.Ck.Cmd
+	basefile = "--basefile " + conf.Ck.Basefile
+	metricsdir = "--metricsdir " + conf.Ck.Metricsdir
+
+	// checkmetrics execution
+	out, err := exec.Command(cmd, basefile, metricsdir).Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(out) == 0 {
+		log.Fatal("no output from: " + cmd)
+	}
+
+	body = fmt.Sprintf("%s", out)
+	SendByEmail(conf, body)
+}


### PR DESCRIPTION
This tool reports by email the obtained PnP results from checktool execution, next it will send the results by email.