### PR TITLE
pullapprove: Require documentation team approval

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -39,3 +39,16 @@ groups:
       - dlespiau
       - GabyCT
       - grahamwhaley
+
+  documentation:
+    conditions:
+      files:
+        include:
+          - "*.rst"
+          - "*.md"
+        exclude:
+          - "vendor/*"
+    required: 1
+    users:
+      - iphutch
+      - rcaballeromx


### PR DESCRIPTION
Require that documentation team approves changes to the
documentation files in this repository, excluding vendoring docs.

Fixes #108.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>