### PR TITLE
gitignore: Ignore fetchbranches binary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /cmd/checkcommits/checkcommits
+/cmd/fetchbranches/fetchbranches
 ginkgo


### PR DESCRIPTION
Add the fetchbranches binary to the .gitignore file.

Fixes #111.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>