### PR TITLE
CI: Add additional project approvers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -34,6 +34,8 @@ groups:
   approvers:
     required: 1
     users:
-      - GabyCT
       - chavafg
       - devimc
+      - dlespiau
+      - GabyCT
+      - grahamwhaley

--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,8 @@ reviewers:
 approvers:
 - chavafg
 - devimc
+- dlespiau
 - GabyCT
+- grahamwhaley
 
 


### PR DESCRIPTION
Add @dlespiau and @grahamwhaley as additional project approvers.

Fixes #116.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>