### PR TITLE
CI: Install btrfs-progs for crio build.

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -17,7 +17,7 @@
 set -e
 
 echo "Install dependencies: libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev libdevmapper-dev btrfs-tools"
-sudo apt-get install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev libdevmapper-dev btrfs-tools
+sudo apt-get install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev libdevmapper-dev btrfs-tools btrfs-progs
 
 echo "Get CRI-O sources"
 go get -d github.com/kubernetes-incubator/cri-o || true


### PR DESCRIPTION
CRI-O on Ubuntu now seems to need not only the "btrfs-tools" package but
now also the "btrfs-progs" package.

Fixes #127.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>