### PR TITLE
checkcommits: Fix spelling error found by misspell

### DIFF
--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -377,7 +377,7 @@ func TestCheckCommitBody(t *testing.T) {
 		expectFixes bool
 	}
 
-	// create a string that is definately longer than
+	// create a string that is definitely longer than
 	// the allowed line length
 	lotsOfFixes := makeLongFixes(defaultMaxBodyLineLength)
 


### PR DESCRIPTION
Apparently this is 'definately' the most mis-spelled word
in the English language.

Fixes: #130

Signed-off-by: Graham Whaley <graham.whaley@intel.com>