### PR TITLE
checkcommits: print out details obtained from CI

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -416,6 +416,7 @@ func detectCIEnvironment() (commit, dstBranch, srcBranch string) {
 
 	if verbose && name != "" {
 		fmt.Printf("Detected %v Environment\n", name)
+		fmt.Printf("Using Commit %v, source branch %v, destination branch %v\n", commit, srcBranch, dstBranch)
 	}
 
 	return commit, dstBranch, srcBranch


### PR DESCRIPTION
Print out, under verbose mode, the details of the information
we have extracted from the CI environment.

Fixes: #135

Signed-off-by: Graham Whaley <graham.whaley@intel.com>