### PR TITLE
checkcommits: Do not do Fixes check unless requested

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -147,9 +147,11 @@ func checkCommitBodyLine(config *CommitConfig, commit string, line string,
 		}
 	}
 
-	fixesMatches := config.FixesPattern.FindStringSubmatch(line)
-	if fixesMatches != nil {
-		config.FoundFixes = true
+	if config.NeedFixes && config.FixesPattern != nil {
+		fixesMatches := config.FixesPattern.FindStringSubmatch(line)
+		if fixesMatches != nil {
+			config.FoundFixes = true
+		}
 	}
 
 	if config.NeedSOBS {


### PR DESCRIPTION
Running checkcommits without --need-fixes still tries to invoke
the FixesPattern regex (that has not been configured), and results
in NULL deref crash.
Gaurd the FixesPattern regex invocation in a conf.NeedFixes check

Fixes: #147

Signed-off-by: Graham Whaley <graham.whaley@intel.com>