### PR TITLE
CI: execute run_fetch_branches_tool only when testing a PR

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -25,8 +25,13 @@ cidir=$(dirname "$0")
 echo "Set up environment"
 bash -f ${cidir}/setup_env_ubuntu.sh
 
-echo "Building and running the fetch branches tool"
-bash -f ${cidir}/run_fetch_branches_tool.sh
+# This should only run when running tests for a PR
+# since it looks for PULL_REQUEST_NUMBER environment
+# variable.
+if [ -n "$PULL_REQUEST_NUMBER" ]; then
+	echo "Building and running the fetch branches tool"
+	bash -f "${cidir}/run_fetch_branches_tool.sh"
+fi
 
 echo "Install shim"
 bash -f ${cidir}/install_shim.sh


### PR DESCRIPTION
run_fetch_branches_tool is designed to run successfully
only for testing PRs. Adding a validation to run only when
env variable "PULL_REQUEST_NUMBER" exists.

Fixes #156.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>