### PR TITLE
localCI: add missing environment variables

### DIFF
--- a/cmd/localCI/README.rst
+++ b/cmd/localCI/README.rst
@@ -41,6 +41,8 @@ Before running the commands of each stage, **localCI** exports the following env
 +---------------------+----------------------+-----------------------------------------------------+
 | LOCALCI_REPO_SLUG   | E.g foo/bar          | Repository owner / repository name                  |
 +---------------------+----------------------+-----------------------------------------------------+
+| LOCALCI_PR_NUMBER   | E.g 23               | Pull request number                                 |
++---------------------+----------------------+-----------------------------------------------------+
 
 
 Configuration file

--- a/cmd/localCI/repo.go
+++ b/cmd/localCI/repo.go
@@ -185,7 +185,7 @@ func (r *Repo) setup() error {
 	// add environment variables
 	r.env = os.Environ()
 	r.env = append(r.env, defaultEnv...)
-	repoSlug := fmt.Sprintf("LOCALCI_REPO_SLUG=\"%s/%s\"", r.cvr.getOwner(), r.cvr.getRepo())
+	repoSlug := fmt.Sprintf("LOCALCI_REPO_SLUG=%s/%s", r.cvr.getOwner(), r.cvr.getRepo())
 	r.env = append(r.env, repoSlug)
 
 	return nil
@@ -409,6 +409,9 @@ func (r *Repo) runTest(pr *PullRequest) error {
 	if len(langEnv) > 0 {
 		pr.Env = append(pr.Env, langEnv...)
 	}
+
+	// appends other environment variables
+	prNumber := fmt.Sprintf("LOCALCI_PR_NUMBER=%d", pr.Number)
 
 	// run stages
 	stages := []struct {


### PR DESCRIPTION
with this patch localCI exports next environment variables
before start a process:
- LOCALCI_PR_NUMBER

fixes #163

Signed-off-by: Julio Montes <julio.montes@intel.com>