### PR TITLE
run_all_metrics: detect script path

### DIFF
--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -16,7 +16,9 @@
 
 set -e
 
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
 echo "Running all metrics tests"
 
 # Run the time tests
-bash metrics/time/docker_workload_time.sh true busybox $RUNTIME 100
+bash ${SCRIPT_PATH}/time/docker_workload_time.sh true busybox $RUNTIME 100


### PR DESCRIPTION
Add SCRIPT_PATH to run_all_metrics.sh script so it can execute
tests successfully from any location.

Fixes #168

Signed-off-by: Brett T. Warden <brett.t.warden@intel.com>