### PR TITLE
run_all_metrics: Check value of RUNTIME

### DIFF
--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -17,6 +17,14 @@
 set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/lib/common.bash"
+
+# Check arguments
+if [[ ! -v RUNTIME ]]; then
+    die Variable RUNTIME must be set to the name of your CC runtime
+fi
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
 echo "Running all metrics tests"
 


### PR DESCRIPTION
Environment variable RUNTIME must be defined before running this test.
Verify that it's set to an integer that's greater than zero.

Fixes #172

Signed-off-by: Brett T. Warden <brett.t.warden@intel.com>