### PR TITLE
functional: Implement standalone testing of the exec command

### DIFF
--- a/functional/run_test.go
+++ b/functional/run_test.go
@@ -39,7 +39,7 @@ var _ = Describe("run", func() {
 	)
 
 	BeforeEach(func() {
-		container, err = NewContainer([]string{})
+		container, err = NewContainer([]string{}, false)
 		Ω(container).ShouldNot(BeNil())
 		Ω(err).ShouldNot(HaveOccurred())
 	})
@@ -74,7 +74,7 @@ var _ = Describe("run", func() {
 	)
 
 	BeforeEach(func() {
-		container, err = NewContainer([]string{"true"})
+		container, err = NewContainer([]string{"true"}, false)
 		Ω(container).ShouldNot(BeNil())
 		Ω(err).ShouldNot(HaveOccurred())
 	})


### PR DESCRIPTION
We are submitting patches to the runtime repository in order to
fix the behavior of the exec command, but we were missing some
tests to validate those expected behaviors.

This patch adds some testing of the exec command when it is
either started "attached" or "detached" from the shell.

Fixes #171