### PR TITLE
common: implement helper function to find qemu

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -42,3 +42,75 @@ function save_results(){
 	bash $LIB_DIR/send_results.sh -n "$1" -a "$2" -r "$3" -u "$4"
 }
 
+function get_hypervisor_from_toml(){
+    ## Regular expressions used for TOML parsing
+    # Matches a section header
+    section_re="^\s*\[(\S+)]"
+    # Matches the name of the hypervisor section
+    hypervisor_re="^hypervisor(\..*)?"
+    # Matches the variable containing the qemu path
+    qemu_re="^\s*path\s*=\s*\"([^\"]+)"
+
+    # Case insensitive
+    shopt -s nocasematch
+
+    for line in "$@"; do
+        if [[ $line =~ $section_re ]]; then
+            # New section
+            section=${BASH_REMATCH[1]}
+        elif [[ $section =~ $hypervisor_re ]]; then
+            # Look for qemu path
+            if [[ $line =~ $qemu_re ]]; then
+                # Found it
+                qemu_path="${BASH_REMATCH[1]}"
+                echo "${qemu_path}"
+                break;
+            fi
+        fi
+    done
+}
+
+# Find a reasonable path to the hypervisor on this system
+function get_qemu_path(){
+   # Create a list of potential configuration files
+    declare -a conf_files
+
+    # Use cc-env, if available
+    CC_RUNTIME=$(command -v cc-runtime)
+    if [[ $? -eq 0 ]] && [[ -n ${CC_RUNTIME} ]]; then
+        cc_env_tmp=$(mktemp cc-env.XXXX)
+        ${CC_RUNTIME} cc-env > "${cc_env_tmp}"
+        conf_files+=("${cc_env_tmp}")
+    fi
+
+    # Search for other configuration files
+    conf_files+=("${LIB_DIR}/../../../runtime/config/configuration.toml")
+    conf_files+=($(find /etc -type f -name configuration.toml -exec \
+        grep -l 'hypervisor.qemu' {} + 2>/dev/null))
+
+    # Check the potential files sequentially
+    for conf_file in "${conf_files[@]}"; do
+        [[ -f "${conf_file}" ]] || continue
+
+        # Attempt to parse the found config file (TOML)
+        declare -a config
+        while read line; do
+            config+=("$line")
+        done < "${conf_file}"
+        qemu_path=$(get_hypervisor_from_toml "${config[@]}")
+
+        # Got one?
+        [[ -n "${qemu_path}" ]] || continue;
+        [[ -x "${qemu_path}" ]] && break;
+    done
+
+    # Cleanup
+    [[ -n "${cc_env_tmp}" ]] && rm "${cc_env_tmp}"
+
+    # Check whether we got a good result
+    [[ -n "$qemu_path" ]] || die Failed to find qemu path in $conf_file
+    [[ -f "$qemu_path" ]] || die "$qemu_path does not exist"
+    [[ -x "$qemu_path" ]] || die "$qemu_path is not executable"
+
+    echo "$qemu_path"
+}


### PR DESCRIPTION
Adds a helper function to the metrics common library to extract the qemu
path from "cc-runtime cc-env" or configuration files at runtime. This
allows several of the network metrics tests to be converted to static
scripts instead of generated via autotools.

Fixes #190

Signed-off-by: Brett T. Warden <brett.t.warden@intel.com>