### PR TITLE
localCI: set default account identity

### DIFF
--- a/cmd/localCI/github.go
+++ b/cmd/localCI/github.go
@@ -219,7 +219,8 @@ func (g *Github) downloadPullRequest(pr int, workingDirectory string) (string, e
 	}
 
 	stderr.Reset()
-	cmd = exec.Command("git", "pull", "--no-edit", "origin", fmt.Sprintf("pull/%d/head", pr))
+	cmd = exec.Command("git", "-c", "user.name='Foo Bar'", "-c", "user.email='foo@bar.com'",
+		"pull", "--no-edit", "origin", fmt.Sprintf("pull/%d/head", pr))
 	cmd.Dir = projectDirectory
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
running as a systemd service git is not able to
read the ~/.gitconfig file therefore this patch adds
a default account identity to avoid errors running the
git command

fixes #191

Signed-off-by: Julio Montes <julio.montes@intel.com>