### PR TITLE
localCI: make the logs generated in each stage accesible

### DIFF
--- a/cmd/localCI/pullRequest.go
+++ b/cmd/localCI/pullRequest.go
@@ -105,14 +105,14 @@ func (pr *PullRequest) Equal(rpr PullRequest) bool {
 // runStage runs a specific stage with the specific commands
 func (pr *PullRequest) runStage(stage string, commands []string) error {
 	stdoutFile := filepath.Join(pr.LogDir, fmt.Sprintf("%s.stdout", stage))
-	stdout, err := os.OpenFile(stdoutFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0640)
+	stdout, err := os.OpenFile(stdoutFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, logFileMode)
 	if err != nil {
 		return err
 	}
 	defer stdout.Close()
 
 	stderrFile := filepath.Join(pr.LogDir, fmt.Sprintf("%s.stderr", stage))
-	stderr, err := os.OpenFile(stderrFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0640)
+	stderr, err := os.OpenFile(stderrFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, logFileMode)
 	if err != nil {
 		return err
 	}

--- a/cmd/localCI/repo.go
+++ b/cmd/localCI/repo.go
@@ -98,7 +98,8 @@ type Repo struct {
 const (
 	defaultLogDir      = "/var/log/localCI"
 	defaultRefreshTime = "30s"
-	logDirMode         = 0640
+	logDirMode         = 0755
+	logFileMode        = 0664
 )
 
 var defaultEnv = []string{"CI=true", "LOCALCI=true"}


### PR DESCRIPTION
in order to make the logs generated in each testing stage
this patch change the mode of the log directory to 0755 and
the mode of the log files to 0664

fixes #197

Signed-off-by: Julio Montes <julio.montes@intel.com>