### PR TITLE
.ci: Install q35 at /usr/bin instead of /usr/local/bin

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -54,7 +54,7 @@ git checkout qemu-lite-v2.9.0
 	--enable-cap-ng --target-list=x86_64-softmmu
 make -j$(nproc)
 sudo -E PATH=$PATH sh -c "make install"
-sudo -E mv $(which qemu-system-x86_64) /usr/local/bin/qemu-q35-system-x86_64
+sudo -E mv $(which qemu-system-x86_64) /usr/bin/qemu-q35-system-x86_64
 popd
 rm -rf ${qemu_dir}
 


### PR DESCRIPTION
The path where q35 is installed is not compliant with the one expected
by the build, meaning that tests with q35 machine type are failing
because the binary cannot be found.

Fixes #206