### PR TITLE
CI: exclude all vendor/*.md's from pullaprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -47,9 +47,12 @@ groups:
           - "*.rst"
           - "*.md"
         exclude:
+# Don't include the vendor subdirs for docs review, as the docs files
+# in those trees our not under our control.
+# Exclude the main top level vendor dir, and all vendor dirs in all
+# sub projects.
           - "vendor/*"
-          - "cmd/fetchbranches/vendor/*"
-          - "cmd/localCI/vendor/*"
+          - "*/vendor/*"
     required: 1
     users:
       - iphutch


### PR DESCRIPTION
We now have multiple sub-projects that have their own vendor
trees with .md files in them we do not want docs review to happen
for (as they are out of our control). Thus, exclude all vendor dirs
through the whole tree for .md file review.

Fixes: #209

Signed-off-by: Graham Whaley <graham.whaley@intel.com>