### PR TITLE
tests: add docker info integration test

### DIFF
--- a/integration/docker/info_test.go
+++ b/integration/docker/info_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	. "github.com/clearcontainers/tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _= Describe ("info", func() {
+	var (
+		exitCode  int
+		command   *Command
+	)
+
+	Context("info with docker", func() {
+		BeforeEach(func() {
+			command = NewCommand(Docker, "info")
+			exitCode = command.Run()
+		})
+		It("should not be empty", func () {
+			Expect(exitCode).To(Equal(0))
+			Expect(command.Stdout.String()).To(ContainSubstring("Runtime"))
+		})
+	})
+})


### PR DESCRIPTION
This will test the docker info command

Fixes #227

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>