### PR TITLE
.ci: Use a different path to download devicemapper version

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -63,7 +63,7 @@ sudo -E apt-get install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgm
 
 echo "Install libdevmapper"
 devmapper_version="2.02.172"
-curl -LOk ftp://sources.redhat.com/pub/lvm2/LVM2.${devmapper_version}.tgz
+curl -LOk ftp://sources.redhat.com/pub/lvm2/releases/LVM2.${devmapper_version}.tgz
 tar -xf LVM2.${devmapper_version}.tgz
 pushd LVM2.${devmapper_version}/
 ./configure


### PR DESCRIPTION
All the releases are stored at a different path than the one we
had in our script, and this patch will allow us to avoid our CI
to be broken.

Fixes #229