### PR TITLE
CI: Add scripts to launch a ciao-down environment

### DIFF
--- a/.ci/ciao_down_run.sh
+++ b/.ci/ciao_down_run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+source "$HOME/vm_info"
+cidir=$(dirname $(readlink -f $0))
+ssh_options="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
+ssh_key="$HOME/.ciao-down/id_rsa"
+runtime_config_file="/etc/clear-containers/configuration.toml"
+
+echo "Execute Tests"
+# Change the default POD memory to 1024 MB since the ciao-down
+# machines are being launched with 2048 MB of memory
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" \
+	"cd ${cidir}/.. && sudo sed -i 's/#default_mem.*/default_memory = 1024/' $runtime_config_file"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "cd ${cidir}/.. && sudo -E PATH=\$PATH make check"

--- a/.ci/ciao_down_setup.sh
+++ b/.ci/ciao_down_setup.sh
@@ -93,5 +93,4 @@ echo "Install repo inside nested VM"
 ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "$(typeset -f); install_repo_inside_vm"
 
 echo "Install dependencies inside the VM"
-ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "${cidir}/ciao_down_setup_env_ubuntu.sh"
-ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "${cidir}/ciao_down_setup_cc3.sh"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "${cidir}/setup.sh"

--- a/.ci/ciao_down_setup.sh
+++ b/.ci/ciao_down_setup.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This setup will be used to run the CI tests under ciao-down
+# under SemaphoreCI. This will avoid issues with the old packages
+# that comes in the SempahoreCI environment (Ubuntu 14.04). 
+
+set -e
+
+cidir=$(dirname "$(readlink -f "$0")")
+
+if [ -z $CI ] || [ -z "$LOCALCI_REPO_SLUG" ] || [ -z "$LOCALCI" ]; then
+	echo "	If you are running locally, please set environment variables
+	CI=true
+	LOCALCI=true
+	LOCALCI_REPO_SLUG with the value of the repo you want to test.
+	For example:
+	export LOCALCI_REPO_SLUG=clearcontainers/tests
+	If you want to test an specific PR, please also add env variable:
+	LOCALCI_PR_NUMBER, for example:
+	export LOCALCI_PR_NUMBER=100" && exit 1
+fi
+
+ciao_repo="github.com/01org/ciao"
+
+# This function will clone the repo inside the VM and
+# get the current PR that will be tested.
+function install_repo_inside_vm(){
+	export $(cat "${HOME}/ci_environment")
+	repo_slug="$LOCALCI_REPO_SLUG"
+	pr_number="$LOCALCI_PR_NUMBER"
+	if [ -n "$SEMAPHORE" ]; then
+		repo_slug="$SEMAPHORE_REPO_SLUG"
+		pr_number="$PULL_REQUEST_NUMBER"
+	fi
+	go get -d "github.com/${repo_slug}" || true
+	if [ -n "$pr_number" ]; then
+		pushd "${GOPATH}/src/github.com/${repo_slug}"
+		git fetch origin "refs/pull/${pr_number}/head:pull_${pr_number}"
+		git checkout "pull_${pr_number}"
+	fi
+}
+
+# Get ciao-down repository
+go get -u -t -d -v "${ciao_repo}/..." || true
+pushd "${GOPATH}/src/${ciao_repo}"
+go install -v ./...
+popd
+export PATH=$GOPATH/bin:$PATH
+
+# Provide access to /dev/kvm to the curent user to launch VMs using ciao-down
+sudo chmod a+rw /dev/kvm
+
+# Execute ciao-down
+vm_cpus=2
+vm_mem=2
+ciao-down create -debug -cpus "$vm_cpus" -mem "$vm_mem" "file://${cidir}/data/cc3-ubuntu-xenial.yaml"
+
+# Get LocalCI or SemaphoreCI Env variables that may be useful inside the ciao-down VM
+echo "Get Semaphore Env Variables"
+ci_environment_file="$HOME/ci_environment"
+env | egrep "PULL_REQ|SLUG|SEMAPHORE|BRANCH|CI" > "$ci_environment_file" || true
+
+# Get information to connect via SSH
+ssh_options="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
+ssh_key="$HOME/.ciao-down/id_rsa"
+
+vm_info_file="$HOME/vm_info"
+myssh=$(ciao-down status | grep ssh |  cut -d : -f 2)
+vm_ip=$(echo "$myssh" | cut -d " " -f 11)
+echo "vm_ip=$vm_ip" > "$vm_info_file"
+vm_port=$(echo "$myssh" | cut -d " " -f 13)
+echo "vm_port=$vm_port" >> "$vm_info_file"
+
+echo "Add CI Environment Variables to nested VM"
+scp -r -q $ssh_options -i "$ssh_key" -P "$vm_port" "$ci_environment_file" "$USER@$vm_ip:"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "sudo bash -c \"cat $ci_environment_file >> /etc/environment\""
+
+echo "Install repo inside nested VM"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "$(typeset -f); install_repo_inside_vm"
+
+echo "Install dependencies inside the VM"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "${cidir}/ciao_down_setup_env_ubuntu.sh"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "${cidir}/ciao_down_setup_cc3.sh"

--- a/.ci/ciao_down_teardown.sh
+++ b/.ci/ciao_down_teardown.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+source "$HOME/vm_info"
+cidir=$(dirname $(readlink -f $0))
+ssh_options="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
+ssh_key="$HOME/.ciao-down/id_rsa"
+runtime_log_file="/var/lib/clear-containers/runtime/runtime.log"
+
+echo "Execute Tests"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "sudo cat $runtime_log_file"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "sudo journalctl -u cc-proxy"
+ssh $ssh_options -i "$ssh_key" "$USER@$vm_ip" -p "$vm_port" "sudo journalctl -u crio"

--- a/.ci/data/cc3-ubuntu-xenial.yaml
+++ b/.ci/data/cc3-ubuntu-xenial.yaml
@@ -1,0 +1,68 @@
+---
+base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+base_image_name: Ubuntu 16.04
+...
+---
+...
+---
+{{- define "ENV" -}}
+{{proxyVars .}}
+{{- print " DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true " -}}
+{{end}}
+{{define "GO_VERSION"}}1.8.3{{end}}
+#cloud-config
+users:
+  - name: {{.User}}
+    gecos: CC Tester User
+    lock-passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - {{.PublicKey}}
+
+write_files:
+{{- if len $.HTTPProxy }}
+ - content: |
+     [Service]
+     Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},{{.Hostname}}{{end}}"
+   path: /etc/systemd/system/docker.service.d/http-proxy.conf
+{{- end}}
+{{with proxyEnv . 5}}
+ - content: |
+{{.}}
+   path: /etc/environment
+{{end}}
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+package_upgrade: {{with .PackageUpgrade}}{{.}}{{else}}false{{end}}
+
+runcmd:
+ - {{beginTask . "Booting VM"}}
+ - {{endTaskOk . }}
+
+ - {{beginTask . (printf "Adding %s to /etc/hosts" .Hostname) }}
+ - echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts
+ - {{endTaskCheck .}}
+
+ - echo "GOPATH=\"{{$.GoPath}}\"" >> /etc/environment
+ - echo "PATH=\"$PATH:/usr/local/go/bin:{{$.GoPath}}/bin\""  >> /etc/environment
+
+ - {{beginTask . "Downloading Go" }}
+ - {{template "ENV" .}} curl "https://storage.googleapis.com/golang/go{{template "GO_VERSION" . }}.linux-amd64.tar.gz" -o "/tmp/go{{template "GO_VERSION" .}}.linux-amd64.tar.gz"
+ - {{endTaskCheck .}}
+
+ - {{beginTask . "Unpacking Go" }}
+ - tar -C /usr/local -xzf /tmp/go{{template "GO_VERSION" . }}.linux-amd64.tar.gz
+ - {{endTaskCheck .}}
+
+ - rm /tmp/go{{template "GO_VERSION" . }}.linux-amd64.tar.gz
+
+ - {{finished .}}
+
+...

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -17,28 +17,39 @@
 set -e
 
 cidir=$(dirname "$0")
+source "$cidir/../test-versions.txt"
+source "/etc/os-release"
+
+if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
+	echo "enable Nested Virtualization"
+	sudo modprobe -r kvm_intel
+	sudo modprobe kvm_intel nested=1
+fi
 
 echo "Add clear containers sources to apt list"
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearlinux:/preview:/clear-containers-2.1/xUbuntu_16.10/ /' >> /etc/apt/sources.list.d/cc-oci-runtime.list"
-curl -fsSL http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.1/xUbuntu_16.10/Release.key | sudo apt-key add -
-
-echo "Install clear containers dependencies"
-sudo -E apt-get install -y libtool automake autotools-dev autoconf bc
-
-echo "Install chronic"
-sudo -E apt-get install -y moreutils
-
-echo "Install rpm2cpio"
-chronic sudo -E apt-get install -y rpm2cpio
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/clear-containers.list"
+curl -fsSL http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/Release.key | sudo -E apt-key add -
 
 echo "Update apt repositories"
-chronic sudo -E apt-get update
+sudo -E apt update
+
+echo "Install chronic"
+sudo -E apt install -y moreutils
+
+echo "Install clear containers dependencies"
+chronic sudo -E apt install -y libtool automake autotools-dev autoconf bc
 
 echo "Install qemu-lite binary"
-chronic sudo -E apt-get install -y --force-yes qemu-lite
+chronic sudo -E apt install -y --force-yes qemu-lite
+
+echo "Install clear-containers image"
+chronic sudo -E apt install -y --force-yes clear-containers-image
+
+echo "Install CRI-O dependencies for all Ubuntu versions"
+chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev
 
 echo "Install qemu Q35 binary"
-chronic sudo -E apt-get install -y libcap-ng-dev libpixman-1-dev libcap-dev libattr1-dev
+chronic sudo -E apt install -y libcap-ng-dev libpixman-1-dev libcap-dev libattr1-dev
 git clone --branch qemu-lite-v2.9.0 https://github.com/clearcontainers/qemu.git --depth 1
 qemu_dir="qemu"
 pushd ${qemu_dir}
@@ -58,72 +69,90 @@ sudo -E mv $(which qemu-system-x86_64) /usr/bin/qemu-q35-system-x86_64
 popd
 rm -rf ${qemu_dir}
 
-echo "Install CRI-O dependencies"
-sudo -E apt-get install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev
-
-echo "Install libdevmapper"
-devmapper_version="2.02.172"
-curl -LOk ftp://sources.redhat.com/pub/lvm2/releases/LVM2.${devmapper_version}.tgz
-tar -xf LVM2.${devmapper_version}.tgz
-pushd LVM2.${devmapper_version}/
-./configure
-make -j$(nproc) libdm
-sudo -E PATH=$PATH sh -c "make libdm.install"
-popd
-rm -rf LVM2.${devmapper_version}/ LVM2.${devmapper_version}.tgz
-
-echo "Install btrfs-tools"
-sudo -E apt-get install -y asciidoc xmlto --no-install-recommends
-sudo -E apt-get install -y uuid-dev libattr1-dev zlib1g-dev libacl1-dev e2fslibs-dev libblkid-dev liblzo2-dev
-git clone http://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git
-pushd btrfs-progs
-./autogen.sh
-./configure
-make -j$(nproc) btrfs
-sudo -E PATH=$PATH sh -c "make install btrfs"
-popd
-
-clear_release=$(curl -sL https://download.clearlinux.org/latest)
-cc_img_path="/usr/share/clear-containers"
-
-"${cidir}/install_clear_image.sh" ${clear_release} "${cc_img_path}"
-
-bug_url="https://github.com/clearcontainers/runtime/issues/91"
-kernel_clear_release=12760
-kernel_version="4.5-50"
-echo -e "\nWARNING:"
-echo "WARNING: Using backlevel kernel version ${kernel_version} due to bug ${bug_url}"
-echo -e "WARNING:\n"
-
-"${cidir}/install_clear_kernel.sh" ${kernel_clear_release} ${kernel_version} "${cc_img_path}"
-
 echo "Install bison binary"
-chronic sudo -E apt-get install -y bison
-
-echo "Install nsenter"
-nsenter_version="2.30"
-chronic sudo -E apt-get install -y autopoint
-curl -LOk https://www.kernel.org/pub/linux/utils/util-linux/v${nsenter_version}/util-linux-${nsenter_version}.tar.xz
-tar -xf util-linux-${nsenter_version}.tar.xz
-pushd util-linux-${nsenter_version}/
-./autogen.sh
-./configure --without-python --disable-all-programs --enable-nsenter
-make nsenter
-sudo cp nsenter /usr/bin/
-popd
-rm -rf util-linux-${nsenter_version}/ util-linux-${nsenter_version}.tar.xz
-
-echo "Install ostree"
-ostree_dir="ostree"
-chronic sudo -E apt-get install -y liblzma-dev e2p-dev libfuse-dev gtk-doc-tools libarchive-dev
-git clone https://github.com/ostreedev/ostree.git
-pushd ${ostree_dir}
-env NOCONFIGURE=1 ./autogen.sh
-./configure --prefix=/usr
-make -j4
-sudo -E PATH=$PATH sh -c "make install"
-popd
-rm -rf ${ostree_dir}
+chronic sudo -E apt install -y bison
 
 echo "Install libudev-dev"
 chronic sudo -E apt-get install -y libudev-dev
+
+if [ "$VERSION_ID" == "14.04" ]; then
+	echo "Install rpm2cpio"
+	chronic sudo -E apt install -y rpm2cpio
+
+	bug_url="https://github.com/clearcontainers/runtime/issues/91"
+	cc_kernel_path="/usr/share/clear-containers"
+	echo -e "\nWARNING:"
+	echo "WARNING: Using backlevel kernel version ${kernel_version} due to bug ${bug_url}"
+	echo -e "WARNING:\n"
+	"${cidir}/install_clear_kernel.sh" ${kernel_clear_release} ${kernel_version} "${cc_kernel_path}"
+
+	echo "Build and Install libdevmapper"
+	devmapper_version="2.02.172"
+	curl -LOk ftp://sources.redhat.com/pub/lvm2/releases/LVM2.${devmapper_version}.tgz
+	tar -xf LVM2.${devmapper_version}.tgz
+	pushd LVM2.${devmapper_version}/
+	./configure
+	make -j$(nproc) libdm
+	sudo -E PATH=$PATH sh -c "make libdm.install"
+	popd
+	rm -rf LVM2.${devmapper_version}/ LVM2.${devmapper_version}.tgz
+
+	echo "Build Install btrfs-tools"
+	sudo -E apt install -y asciidoc xmlto --no-install-recommends
+	sudo -E apt install -y uuid-dev libattr1-dev libacl1-dev e2fslibs-dev libblkid-dev liblzo2-dev
+	git clone http://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git
+	pushd btrfs-progs
+	./autogen.sh
+	./configure
+	make -j$(nproc) btrfs
+	sudo -E PATH=$PATH sh -c "make install btrfs"
+	popd
+
+	echo "Build and Install nsenter"
+	nsenter_version="2.30"
+	chronic sudo -E apt install -y autopoint
+	curl -LOk https://www.kernel.org/pub/linux/utils/util-linux/v${nsenter_version}/util-linux-${nsenter_version}.tar.xz
+	tar -xf util-linux-${nsenter_version}.tar.xz
+	pushd util-linux-${nsenter_version}/
+	./autogen.sh
+	./configure --without-python --disable-all-programs --enable-nsenter
+	make nsenter
+	sudo cp nsenter /usr/bin/
+	popd
+	rm -rf util-linux-${nsenter_version}/ util-linux-${nsenter_version}.tar.xz
+
+	echo "Build and Install ostree"
+	ostree_dir="ostree"
+	chronic sudo -E apt install -y liblzma-dev e2p-dev libfuse-dev gtk-doc-tools libarchive-dev
+	git clone https://github.com/ostreedev/ostree.git
+	pushd ${ostree_dir}
+	env NOCONFIGURE=1 ./autogen.sh
+	./configure --prefix=/usr
+	make -j4
+	sudo -E PATH=$PATH sh -c "make install"
+	popd
+	rm -rf ${ostree_dir}
+
+elif [ "$VERSION_ID" == "16.04" ]; then
+	echo "Install Build Tools"
+	sudo -E apt install -y build-essential python pkg-config zlib1g-dev
+
+	echo "Install Clear Containers Kernel"
+	sudo -E apt install -y linux-container
+
+	echo "Install CRI-O dependencies available for Ubuntu 16.04"
+	sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux
+
+	echo "Install os-tree"
+	sudo -E add-apt-repository ppa:alexlarsson/flatpak -y
+	sudo -E apt update
+	sudo -E apt install -y libostree-dev
+
+	echo "Install Docker"
+	docker_url="https://download.docker.com/linux/ubuntu"
+	sudo -E apt install -y apt-transport-https ca-certificates
+	sudo -E add-apt-repository "deb [arch=amd64] ${docker_url} $(lsb_release -cs) stable"
+	curl -fsSL "${docker_url}/gpg" | sudo -E apt-key add -
+	sudo -E apt update
+	sudo -E apt install -y docker-ce
+fi

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,2 +1,13 @@
-#well known working crio tag/commit/branch
+# Well known working crio tag/commit/branch
 crio_version=065960386fce7088bab3fc22af44ebbbf75d3641
+
+# Kernel Version to use on recent Linux Distros
+kernel_clear_release=16680
+kernel_version="4.9.35-76"
+
+# Kernel Version to use for Ubuntu 14.04 (Semaphore Env)
+kernel_clear_release=12760
+kernel_version="4.5-50"
+
+# Go version to use for building and testing Clear Containers
+go_version="1.8.3"


### PR DESCRIPTION
This commit includes a yaml file with the configuration to start
an ubuntu 16.04 environment with the required dependencies for
building and testing Clear Containers 3.0.

There is also a script called `ciao_down_setup.sh` which will
create the environment.

Fixes #223.
Fixes #246.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>