### PR TITLE
.ci: Fix Semaphore CI build by installing libostree from sources

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -112,3 +112,15 @@ make nsenter
 sudo cp nsenter /usr/bin/
 popd
 rm -rf util-linux-${nsenter_version}/ util-linux-${nsenter_version}.tar.xz
+
+echo "Install ostree"
+ostree_dir="ostree"
+chronic sudo -E apt-get install -y liblzma-dev e2p-dev libfuse-dev gtk-doc-tools
+git clone https://github.com/ostreedev/ostree.git
+pushd ${ostree_dir}
+env NOCONFIGURE=1 ./autogen.sh
+./configure --prefix=/usr
+make -j4
+sudo -E PATH=$PATH sh -c "make install"
+popd
+rm -rf ${ostree_dir}


### PR DESCRIPTION
CRI-O is now relying on a new library called libostree and there is
no Ubuntu packages available before Ubuntu 16.10. Because Semaphore
runs on Ubuntu 14.04, we need to install this library from sources.

Fixes #250