### PR TITLE
localCI: remove generated files when make cleaning

### DIFF
--- a/cmd/localCI/Makefile
+++ b/cmd/localCI/Makefile
@@ -93,4 +93,4 @@ check: $(GENERATED_FILES) Makefile
 	$(QUIET_CHECK)go test .
 
 clean:
-	rm -f $(TARGET) $(UNIT_FILES)
+	rm -f $(TARGET) $(UNIT_FILES) $(GENERATED_FILES)


### PR DESCRIPTION
make clean rule was not removing the auto generated source
files. Let's do that, to really be clean.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>