### PR TITLE
ci: add test-versions.txt

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -18,9 +18,13 @@ set -e
 
 cidir=$(dirname "$0")
 
+source "${cidir}/../test-versions.txt"
+
 echo "Get CRI-O sources"
 go get -d github.com/kubernetes-incubator/cri-o || true
 pushd $GOPATH/src/github.com/kubernetes-incubator/cri-o
+git fetch
+git checkout "${crio_version}"
 
 echo "Installing CRI-O"
 make install.tools

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,0 +1,2 @@
+#well known working crio tag/commit/branch
+crio_version=065960386fce7088bab3fc22af44ebbbf75d3641


### PR DESCRIPTION
crio updates has been updated frecuently and
break our ci. Lets add a lock version.

This version could be used for CC 3.0
release notes.

Fixes: #258

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>