### PR TITLE
CI: Fix fetch tool internal source code path

### DIFF
--- a/.ci/run_fetch_branches_tool.sh
+++ b/.ci/run_fetch_branches_tool.sh
@@ -21,13 +21,18 @@ set -e
 
 cidir=$(dirname "$0")
 
-github_repository="src/github.com/clearcontainers/tests/cmd/fetchbranches"
-tool_dir="${GOPATH}/${github_repository}"
+tests_repo="github.com/clearcontainers/tests"
+fetchtool_path="$GOPATH/src/$tests_repo/cmd/fetchbranches"
 
-pushd ${tool_dir} 
+if [ ! -d "$fetchtool_path" ];then
+	go get -d "$tests_repo"
+fi
+
+pushd "$fetchtool_path"
 
 # Building the fetch branches tool
 go build .
+
 # Running the fetch branches tool
 ./fetchbranches
 


### PR DESCRIPTION
As localCI overrides GOPATH, it does not find
the fecth tool source code, this commit verifies
if the source code of fetch tools exists in the
new GOPATH, or if it is necessary to get the
source code.

Fixes: #308

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>