### PR TITLE
Add support for getting baseline file from default path 

### DIFF
--- a/cmd/checkmetrics/Makefile
+++ b/cmd/checkmetrics/Makefile
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TARGET     := checkmetrics
+PREFIX     := /usr
+BINDIR     := $(PREFIX)/bin
+SYSCONFDIR := /etc
+DESTTARGET := $(BINDIR)/$(TARGET)
+BASEFILE   := $(TARGET).toml
+BASELINE   := baseline/$(BASEFILE)
+DESTBASE   := $(SYSCONFDIR)/$(TARGET)/$(BASEFILE)
+
+all:
+	go build -ldflags "-X main.sysBaseFile=$(DESTBASE)" -o $(TARGET)
+
+install:
+	install -D $(TARGET) $(DESTTARGET)
+	install -D $(BASELINE) $(DESTBASE)
+
+clean:
+	rm -f $(DESTTARGET)
+	rm -rf $(SYSCONFDIR)/$(TARGET)
+
+.PHONY: install clean

--- a/cmd/checkmetrics/README.md
+++ b/cmd/checkmetrics/README.md
@@ -24,6 +24,8 @@ do not complete successfully.
 ## baseline TOML layout
 The Metrics CSV files to be checked, and the range that the median of the
 `Results` data is expected to fall within is defined in a TOML file.
+This baseline file can be specified by command line or it is installed
+in `/etc/checkmetrics/checkmetrics.toml` by default.
 
 Each Metric has a separate `[[metric]]` section within the TOML file.
 

--- a/cmd/checkmetrics/baseline/checkmetrics.toml
+++ b/cmd/checkmetrics/baseline/checkmetrics.toml
@@ -1,0 +1,14 @@
+# This file contains baseline expectations
+# for checked results by checkmetrics tool.
+[[metric]]
+# The name of the metrics test, must match
+# that of the generated CSV file
+name = "docker-run-time"
+description = "/bin/true cycle time"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+minval = 0.5
+maxval = 1.5
+
+# ... repeat this for each metric ...

--- a/cmd/checkmetrics/main.go
+++ b/cmd/checkmetrics/main.go
@@ -128,6 +128,10 @@ func processMetrics(context *cli.Context) (err error) {
 	return
 }
 
+// System default path for baseline file
+// the value will be set by Makefile
+var sysBaseFile string = ""
+
 // checkmetrics main entry point.
 // Do the command line processing, load the TOML file, and do the processing
 // against the CSV files
@@ -157,6 +161,7 @@ func main() {
 
 	app.Before = func(context *cli.Context) error {
 		var err error
+		var baseFilePath string
 
 		if path := context.GlobalString("log"); path != "" {
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0640)
@@ -170,17 +175,17 @@ func main() {
 			log.SetLevel(log.DebugLevel)
 		}
 
-		if context.GlobalString("basefile") == "" {
-			log.Error("Must supply basefile argument")
-			return errors.New("Must supply basefile argument")
-		}
-
 		if context.GlobalString("metricsdir") == "" {
 			log.Error("Must supply metricsdir argument")
 			return errors.New("Must supply metricsdir argument")
 		}
 
-		ciBasefile, err = newBasefile(context.GlobalString("basefile"))
+		baseFilePath = context.GlobalString("basefile")
+		if baseFilePath == "" {
+			baseFilePath = sysBaseFile
+		}
+
+		ciBasefile, err = newBasefile(baseFilePath)
 
 		return err
 	}


### PR DESCRIPTION
If the the baseline file path is not specified by command line, checkmetrics tool will look for the baseline file in a system path by default. This baseline file will be shipped during installation step.