### PR TITLE
localCI: do not try to run empty stages

### DIFF
--- a/cmd/localCI/branch.go
+++ b/cmd/localCI/branch.go
@@ -97,7 +97,7 @@ func (b *repoBranch) test(config stageConfig, stages map[string]stage) error {
 
 	runStage := func(stage string) error {
 		s, ok := stages[stage]
-		if ok {
+		if ok && len(s.commands) > 0 {
 			return s.run(config)
 		}
 		return nil


### PR DESCRIPTION
with this patch localCI will not run empty stages
an empty stage does not contain commands

fixes #332

Signed-off-by: Julio Montes <julio.montes@intel.com>