### PR TITLE
ci: Add libudev-dev dependency

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -124,3 +124,6 @@ make -j4
 sudo -E PATH=$PATH sh -c "make install"
 popd
 rm -rf ${ostree_dir}
+
+echo "Install libudev-dev"
+chronic sudo -E apt-get install -y libudev-dev


### PR DESCRIPTION
This is required to compile the agent which now listens
for certain udev events.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>