### PR TITLE
tests: add file close verification to docker export test

### DIFF
--- a/integration/docker/export_test.go
+++ b/integration/docker/export_test.go
@@ -44,7 +44,6 @@ var _ = Describe("export", func() {
 			It("should export filesystem as a tar archive", func() {
 				file, err := ioutil.TempFile(os.TempDir(), "latest.tar")
 				Expect(err).ToNot(HaveOccurred())
-				defer file.Close()
 				defer os.Remove(file.Name())
 				args = []string{"export", "--output", file.Name(), id}
 				runDockerCommand(0, args...)
@@ -52,6 +51,8 @@ var _ = Describe("export", func() {
 				fileInfo, err := file.Stat()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(fileInfo.Size).NotTo(Equal(0))
+				err = file.Close()
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
add a close file verification as well as a verification that
the file is a regular file for the integration docker export test

Fixes #343

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>