### PR TITLE
emailreport: Fix checkmetrics execution tool

### DIFF
--- a/cmd/emailreport/main.go
+++ b/cmd/emailreport/main.go
@@ -107,13 +107,13 @@ func main() {
 
 	// Set checkmetrics configuration
 	cmd = conf.Ck.Cmd
-	basefile = "--basefile " + conf.Ck.Basefile
-	metricsdir = "--metricsdir " + conf.Ck.Metricsdir
+	basefile = conf.Ck.Basefile
+	metricsdir = conf.Ck.Metricsdir
 
 	// checkmetrics execution
-	out, err := exec.Command(cmd, basefile, metricsdir).Output()
+	out, err := exec.Command(cmd, "--basefile", basefile, "--metricsdir", metricsdir).Output()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("checkmetrics execution: ", err)
 	}
 
 	if len(out) == 0 {


### PR DESCRIPTION
emailreport tool fails when it uses checkmetrics
tool for parsing data and sent it by email,
this commit fixes the correct format of checkmetrics
command parameters.

Fixes: #345

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>