### PR TITLE
.ci: Fix Semaphore CI hangs

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -47,3 +47,7 @@ bash -f ${cidir}/install_cni_plugins.sh
 
 echo "Install CRI-O"
 bash -f ${cidir}/install_crio.sh
+
+echo "Drop caches"
+sync
+sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"


### PR DESCRIPTION
Recently, we have seen a lot of hangs during our CI. This is due to
the low memory available inside the Semaphore box, after we run our
setup. That's the reason why this patch drop all the caches at the
end of the setup, freeing a large amount of memory. This allows our
tests to run properly with the right amount of memory.

For information, I have found that after the setup, the free memory
was around 800MiB out of the 4GiB available on the box. Notice that
when the box is started, there is 1.5GiB already used, meaning that
we really have 2.5GiB available.

Fixes #326