### PR TITLE
integration/docker: implement ContainerStop

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -75,3 +75,22 @@ func ContainerRemove(name string) bool {
 
 	return true
 }
+
+// ContainerStop stops a container
+// returns true on success else false
+func ContainerStop(name string) bool {
+	cmd := NewCommand(Docker, "stop", name)
+	if cmd == nil {
+		return false
+	}
+
+	// docker stop takes ~15 seconds
+	cmd.Timeout = 15
+
+	if cmd.Run() != 0 {
+		LogIfFail(cmd.Stderr.String())
+		return false
+	}
+
+	return true
+}

--- a/integration/docker/restart_test.go
+++ b/integration/docker/restart_test.go
@@ -40,8 +40,7 @@ var _ = Describe("restart", func() {
 	Describe("restart with docker", func() {
 		Context("restart a container", func() {
 			It("should be running", func() {
-				args = []string{"stop", id}
-				runDockerCommand(0, args...)
+				Expect(ContainerStop(id)).To(BeTrue())
 				args = []string{"inspect", "--format='{{.State.Running}}'", id}
 				stdout := runDockerCommand(0, args...)
 				Expect(stdout).To(ContainSubstring("false"))


### PR DESCRIPTION
ContainerStop will stop a specific container using a
timeout of 15 seconds, this is because docker stop takes
a lot of time stopping a container

fixes #360

Signed-off-by: Julio Montes <julio.montes@intel.com>