### PR TITLE
CI: update CI scripts to use new qemu-cc with Q35 support

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -41,6 +41,9 @@ export PKGLIBEXECDIR=/usr/libexec/clear-containers
 # For the pause bundle
 export LOCALSTATEDIR=/var
 
+# Qemu Binary with Q35 support
+export QEMUCMD=qemu-cc-system-x86_64
+
 runtime_config_path="${SYSCONFDIR}/clear-containers/configuration.toml"
 
 # Note: This will also install the config file.

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -27,8 +27,8 @@ if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
 fi
 
 echo "Add clear containers sources to apt list"
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/clear-containers.list"
-curl -fsSL http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/xUbuntu_16.04/Release.key | sudo -E apt-key add -
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/xUbuntu_16.04/ /' >> /etc/apt/sources.list.d/clear-containers.list"
+curl -fsSL http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3-staging/xUbuntu_16.04/Release.key | sudo -E apt-key add -
 
 echo "Update apt repositories"
 sudo -E apt update
@@ -39,35 +39,14 @@ sudo -E apt install -y moreutils
 echo "Install clear containers dependencies"
 chronic sudo -E apt install -y libtool automake autotools-dev autoconf bc
 
-echo "Install qemu-lite binary"
-chronic sudo -E apt install -y --force-yes qemu-lite
+echo "Install qemu Q35 binary from OBS"
+chronic sudo -E apt install -y --force-yes qemu-cc
 
 echo "Install clear-containers image"
 chronic sudo -E apt install -y --force-yes clear-containers-image
 
 echo "Install CRI-O dependencies for all Ubuntu versions"
 chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev
-
-echo "Install qemu Q35 binary"
-chronic sudo -E apt install -y libcap-ng-dev libpixman-1-dev libcap-dev libattr1-dev
-git clone --branch qemu-lite-v2.9.0 https://github.com/clearcontainers/qemu.git --depth 1
-qemu_dir="qemu"
-pushd ${qemu_dir}
-git checkout qemu-lite-v2.9.0
-./configure --disable-tools --disable-libssh2 --disable-tcmalloc --disable-glusterfs        \
-	--disable-seccomp --disable-{bzip2,snappy,lzo} --disable-usb-redir --disable-libusb \
-	--disable-libnfs --disable-tcg-interpreter --disable-debug-tcg --disable-libiscsi   \
-	--disable-rbd --disable-spice --disable-attr --disable-cap-ng --disable-linux-aio   \
-	--disable-brlapi --disable-vnc-{jpeg,png,sasl} --disable-rdma --disable-bluez       \
-	--disable-fdt --disable-curl --disable-curses --disable-sdl --disable-gtk           \
-	--disable-tpm --disable-vte --disable-vnc --disable-xen --disable-opengl            \
-	--disable-slirp --enable-trace-backend=nop --enable-virtfs --enable-attr            \
-	--enable-cap-ng --target-list=x86_64-softmmu
-make -j$(nproc)
-sudo -E PATH=$PATH sh -c "make install"
-sudo -E mv $(which qemu-system-x86_64) /usr/bin/qemu-q35-system-x86_64
-popd
-rm -rf ${qemu_dir}
 
 echo "Install bison binary"
 chronic sudo -E apt install -y bison


### PR DESCRIPTION
This change installs the qemu-cc-system-x86_64 binary instead
of the qemu-lite-system-x86_64 binary and configures the runtime
to use the new binary.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>