### PR TITLE
localCI: validate go-github variables before use them

### DIFF
--- a/cmd/localCI/github.go
+++ b/cmd/localCI/github.go
@@ -243,12 +243,16 @@ func (g *Github) getLatestPullRequestComment(pr int, user, body string) (RepoCom
 	for i := len(comments) - 1; i >= 0; i-- {
 		c := comments[i]
 		if len(user) != 0 {
-			if *c.User.Login != user {
+			if c.User == nil || c.User.Login == nil || *c.User.Login != user {
 				continue
 			}
 		}
 
-		if *c.Body == body {
+		if c.CreatedAt == nil {
+			continue
+		}
+
+		if c.Body != nil && *c.Body == body {
 			return RepoComment{
 				User:    user,
 				Comment: body,


### PR DESCRIPTION
To avoid crashes objects returned by go-gihub API must be
validated before use them

fixes #212

Signed-off-by: Julio Montes <julio.montes@intel.com>