### PR TITLE
localCI: use warnf not warn

### DIFF
--- a/cmd/localCI/repo.go
+++ b/cmd/localCI/repo.go
@@ -270,7 +270,7 @@ func (r *Repo) loop() {
 		r.logger.Debugf("requesting master branch: %s", r.MasterBranch)
 		branch, err := newRepoBranch(r.MasterBranch, r.cvr, r.logger)
 		if err != nil {
-			r.logger.Warn("failed to get master branch %s: %s", r.MasterBranch, err)
+			r.logger.Warnf("failed to get master branch %s: %s", r.MasterBranch, err)
 		} else {
 			revisionsToTest = append(revisionsToTest, branch)
 		}
@@ -279,16 +279,16 @@ func (r *Repo) loop() {
 		if r.PR != 0 {
 			// if PR is not 0 then we have to monitor just one PR
 			if err = appendPullRequests(&revisionsToTest, []int{r.PR}); err != nil {
-				r.logger.Warn("failed to append pull request %d", r.PR, err)
+				r.logger.Warnf("failed to append pull request %d", r.PR, err)
 			}
 		} else {
 			// append open pull request
 			r.logger.Debugf("requesting open pull requests")
 			prs, err := r.cvr.getOpenPullRequests()
 			if err != nil {
-				r.logger.Warn("failed to get open pull requests: %s", err)
+				r.logger.Warnf("failed to get open pull requests: %s", err)
 			} else if err = appendPullRequests(&revisionsToTest, prs); err != nil {
-				r.logger.Warn("failed to append pull requests %+v: %s", prs, err)
+				r.logger.Warnf("failed to append pull requests %+v: %s", prs, err)
 			}
 		}
 


### PR DESCRIPTION
since we are using format characters (%s, %d) we have to use
the format version of warn (warnf)

fixes #348

Signed-off-by: Julio Montes <julio.montes@intel.com>