### PR TITLE
 tests: create a wrapper for docker commands

### DIFF
--- a/command.go
+++ b/command.go
@@ -33,12 +33,6 @@ type Command struct {
 	// cmd exec.Cmd
 	cmd *exec.Cmd
 
-	// Stderr process's standard error
-	Stderr bytes.Buffer
-
-	// Stdout process's standard output
-	Stdout bytes.Buffer
-
 	// Timeout is the time limit of seconds of the command
 	Timeout time.Duration
 }
@@ -54,16 +48,19 @@ func init() {
 func NewCommand(path string, args ...string) *Command {
 	c := new(Command)
 	c.cmd = exec.Command(path, args...)
-	c.cmd.Stderr = &c.Stderr
-	c.cmd.Stdout = &c.Stdout
 	c.Timeout = time.Duration(Timeout)
 
 	return c
 }
 
-// Run runs a command returning its exit code
-func (c *Command) Run() int {
+// Run runs a command returning its stdout, stderr and exit code
+func (c *Command) Run() (string, string, int) {
 	LogIfFail("Running command '%s %s'\n", c.cmd.Path, c.cmd.Args)
+
+	var stdout, stderr bytes.Buffer
+	c.cmd.Stdout = &stdout
+	c.cmd.Stderr = &stderr
+
 	if err := c.cmd.Start(); err != nil {
 		LogIfFail("could no start command: %v\n", err)
 	}
@@ -80,12 +77,14 @@ func (c *Command) Run() int {
 	case <-timeout:
 		LogIfFail("Killing process timeout reached '%d' seconds\n", c.Timeout)
 		_ = c.cmd.Process.Kill()
-		return -1
+		return "", "", -1
 
 	case err := <-done:
 		if err != nil {
 			LogIfFail("command failed error '%s'\n", err)
 		}
-		return c.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+
+		exitCode := c.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+		return stdout.String(), stderr.String(), exitCode
 	}
 }

--- a/command.go
+++ b/command.go
@@ -85,6 +85,10 @@ func (c *Command) Run() (string, string, int) {
 		}
 
 		exitCode := c.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+
+		LogIfFail("%+v\nTimeout: %d seconds\nExit Code: %d\nStdout: %s\nStderr: %s\n",
+			c.cmd.Args, c.Timeout, exitCode, stdout.String(), stderr.String())
+
 		return stdout.String(), stderr.String(), exitCode
 	}
 }

--- a/container.go
+++ b/container.go
@@ -15,7 +15,6 @@
 package tests
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -89,7 +88,7 @@ func NewContainer(workload []string, detach bool) (*Container, error) {
 
 // Run the container
 // calls to run command returning its stdout, stderr and exit code
-func (c *Container) Run() (bytes.Buffer, bytes.Buffer, int) {
+func (c *Container) Run() (string, string, int) {
 	args := []string{}
 
 	if c.Debug {
@@ -123,14 +122,13 @@ func (c *Container) Run() (bytes.Buffer, bytes.Buffer, int) {
 	}
 
 	cmd := NewCommand(Runtime, args...)
-	ret := cmd.Run()
 
-	return cmd.Stdout, cmd.Stderr, ret
+	return cmd.Run()
 }
 
 // Delete the container
 // calls to delete command returning its stdout, stderr and exit code
-func (c *Container) Delete(force bool) (bytes.Buffer, bytes.Buffer, int) {
+func (c *Container) Delete(force bool) (string, string, int) {
 	args := []string{"delete"}
 
 	if force {
@@ -142,14 +140,13 @@ func (c *Container) Delete(force bool) (bytes.Buffer, bytes.Buffer, int) {
 	}
 
 	cmd := NewCommand(Runtime, args...)
-	ret := cmd.Run()
 
-	return cmd.Stdout, cmd.Stderr, ret
+	return cmd.Run()
 }
 
 // Kill the container
 // calls to kill command returning its stdout, stderr and exit code
-func (c *Container) Kill(all bool, signal interface{}) (bytes.Buffer, bytes.Buffer, int) {
+func (c *Container) Kill(all bool, signal interface{}) (string, string, int) {
 	args := []string{"kill"}
 
 	if all {
@@ -168,14 +165,13 @@ func (c *Container) Kill(all bool, signal interface{}) (bytes.Buffer, bytes.Buff
 	}
 
 	cmd := NewCommand(Runtime, args...)
-	ret := cmd.Run()
 
-	return cmd.Stdout, cmd.Stderr, ret
+	return cmd.Run()
 }
 
 // Exec the container
 // calls into exec command returning its stdout, stderr and exit code
-func (c *Container) Exec(process Process) (bytes.Buffer, bytes.Buffer, int) {
+func (c *Container) Exec(process Process) (string, string, int) {
 	args := []string{}
 
 	if c.Debug {
@@ -207,14 +203,13 @@ func (c *Container) Exec(process Process) (bytes.Buffer, bytes.Buffer, int) {
 	args = append(args, process.Workload...)
 
 	cmd := NewCommand(Runtime, args...)
-	ret := cmd.Run()
 
-	return cmd.Stdout, cmd.Stderr, ret
+	return cmd.Run()
 }
 
 // List the containers
 // calls to list command returning its stdout, stderr and exit code
-func (c *Container) List(format string, quiet bool, all bool) (bytes.Buffer, bytes.Buffer, int) {
+func (c *Container) List(format string, quiet bool, all bool) (string, string, int) {
 	args := []string{"list"}
 
 	if format != "" {
@@ -230,9 +225,8 @@ func (c *Container) List(format string, quiet bool, all bool) (bytes.Buffer, byt
 	}
 
 	cmd := NewCommand(Runtime, args...)
-	ret := cmd.Run()
 
-	return cmd.Stdout, cmd.Stderr, ret
+	return cmd.Run()
 }
 
 // SetWorkload sets a workload for the container
@@ -288,7 +282,7 @@ func (c *Container) isListed() bool {
 		return false
 	}
 
-	return strings.Contains(stdout.String(), *c.ID)
+	return strings.Contains(stdout, *c.ID)
 }
 
 func (c *Container) isWorkloadRunning() bool {

--- a/docker.go
+++ b/docker.go
@@ -157,3 +157,18 @@ func DockerAttach(args ...string) (string, string, int) {
 	// 15 seconds should be enough to wait for the container workload
 	return runDockerCommandWithTimeout(15, "attach", args...)
 }
+
+// DockerCommit creates a new image from a container's changes
+func DockerCommit(args ...string) (string, string, int) {
+	return runDockerCommand("commit", args...)
+}
+
+// DockerImages list images
+func DockerImages(args ...string) (string, string, int) {
+	return runDockerCommand("images", args...)
+}
+
+// DockerRmi removes one or more images
+func DockerRmi(args ...string) (string, string, int) {
+	return runDockerCommand("rmi", args...)
+}

--- a/docker.go
+++ b/docker.go
@@ -146,3 +146,8 @@ func DockerRun(args ...string) (string, string, int) {
 func DockerKill(args ...string) (string, string, int) {
 	return runDockerCommand("kill", args...)
 }
+
+// DockerVolume manages volumes
+func DockerVolume(args ...string) (string, string, int) {
+	return runDockerCommand("volume", args...)
+}

--- a/docker.go
+++ b/docker.go
@@ -172,3 +172,13 @@ func DockerImages(args ...string) (string, string, int) {
 func DockerRmi(args ...string) (string, string, int) {
 	return runDockerCommand("rmi", args...)
 }
+
+// DockerCp copies files/folders between a container and the local filesystem
+func DockerCp(args ...string) (string, string, int) {
+	return runDockerCommand("cp", args...)
+}
+
+// DockerExec runs a command in a running container
+func DockerExec(args ...string) (string, string, int) {
+	return runDockerCommand("exec", args...)
+}

--- a/docker.go
+++ b/docker.go
@@ -151,3 +151,9 @@ func DockerKill(args ...string) (string, string, int) {
 func DockerVolume(args ...string) (string, string, int) {
 	return runDockerCommand("volume", args...)
 }
+
+// DockerAttach attach to a running container
+func DockerAttach(args ...string) (string, string, int) {
+	// 15 seconds should be enough to wait for the container workload
+	return runDockerCommandWithTimeout(15, "attach", args...)
+}

--- a/docker.go
+++ b/docker.go
@@ -182,3 +182,13 @@ func DockerCp(args ...string) (string, string, int) {
 func DockerExec(args ...string) (string, string, int) {
 	return runDockerCommand("exec", args...)
 }
+
+// DockerPs list containers
+func DockerPs(args ...string) (string, string, int) {
+	return runDockerCommand("ps", args...)
+}
+
+// DockerCreate creates a new container
+func DockerCreate(args ...string) (string, string, int) {
+	return runDockerCommand("create", args...)
+}

--- a/functional/commands_test.go
+++ b/functional/commands_test.go
@@ -35,13 +35,14 @@ func withInexistentID(command string) TableEntry {
 
 var _ = Describe("commands", func() {
 	var exitCode int
+	var stderr string
 
 	DescribeTable("without a container ID should fail",
 		func(cmd *Command) {
-			exitCode = cmd.Run()
+			_, stderr, exitCode = cmd.Run()
 
 			Ω(exitCode).ShouldNot(Equal(0))
-			Ω(cmd.Stderr.String()).ShouldNot(BeEmpty())
+			Ω(stderr).ShouldNot(BeEmpty())
 		},
 		withoutID("kill"),
 		withoutID("delete"),
@@ -51,10 +52,10 @@ var _ = Describe("commands", func() {
 
 	DescribeTable("with a inexistent container ID should fail",
 		func(cmd *Command) {
-			exitCode = cmd.Run()
+			_, stderr, exitCode = cmd.Run()
 
 			Ω(exitCode).ShouldNot(Equal(0))
-			Ω(cmd.Stderr.String()).ShouldNot(BeEmpty())
+			Ω(stderr).ShouldNot(BeEmpty())
 		},
 		withInexistentID("kill"),
 		withInexistentID("delete"),

--- a/functional/exec_test.go
+++ b/functional/exec_test.go
@@ -103,12 +103,12 @@ var _ = Describe("exec", func() {
 			Expect(exitCode).Should(Equal(0))
 
 			if expectedOutput != "" {
-				Expect(stdout.String()).Should(ContainSubstring(expectedOutput))
+				Expect(stdout).Should(ContainSubstring(expectedOutput))
 			} else {
-				Expect(stdout.String()).Should(BeEmpty())
+				Expect(stdout).Should(BeEmpty())
 			}
 
-			Expect(stderr.String()).Should(BeEmpty())
+			Expect(stderr).Should(BeEmpty())
 		},
 		execDetachOutput(false),
 		execDetachOutput(true),

--- a/functional/options_test.go
+++ b/functional/options_test.go
@@ -31,16 +31,16 @@ func withOption(option string, fail bool) TableEntry {
 var _ = Describe("global options", func() {
 	DescribeTable("option",
 		func(command *Command, fail bool) {
-			exitCode := command.Run()
+			stdout, stderr, exitCode := command.Run()
 
 			if fail {
 				Expect(exitCode).NotTo(Equal(0))
-				Expect(command.Stderr.String()).NotTo(BeEmpty())
-				Expect(command.Stdout.String()).NotTo(BeEmpty())
+				Expect(stderr).NotTo(BeEmpty())
+				Expect(stdout).NotTo(BeEmpty())
 			} else {
 				Expect(exitCode).To(Equal(0))
-				Expect(command.Stderr.String()).To(BeEmpty())
-				Expect(command.Stdout.String()).NotTo(BeEmpty())
+				Expect(stderr).To(BeEmpty())
+				Expect(stdout).NotTo(BeEmpty())
 			}
 		},
 		withOption("--version", shouldNotFail),

--- a/functional/run_test.go
+++ b/functional/run_test.go
@@ -53,8 +53,7 @@ var _ = Describe("run", func() {
 		func(workload []string, expectedExitCode int) {
 			Ω(container.SetWorkload(workload)).Should(Succeed())
 
-			_, stderr, exitCode := container.Run()
-			LogIfFail(stderr.String())
+			_, _, exitCode := container.Run()
 
 			Ω(expectedExitCode).Should(Equal(exitCode))
 		},
@@ -89,14 +88,13 @@ var _ = Describe("run", func() {
 			Ω(container.RemoveOption(option)).Should(Succeed())
 
 			_, stderr, exitCode := container.Run()
-			LogIfFail(stderr.String())
 
 			if fail {
 				Ω(exitCode).ShouldNot(Equal(0))
-				Ω(stderr.String()).ShouldNot(BeEmpty())
+				Ω(stderr).ShouldNot(BeEmpty())
 			} else {
 				Ω(exitCode).Should(Equal(0))
-				Ω(stderr.String()).Should(BeEmpty())
+				Ω(stderr).Should(BeEmpty())
 			}
 		},
 		withoutOption("--bundle", shouldFail),

--- a/integration/docker/attach_test.go
+++ b/integration/docker/attach_test.go
@@ -15,22 +15,26 @@
 package docker
 
 import (
+	"fmt"
+
 	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("attach", func() {
+var _ = Describe("docker attach", func() {
 	var (
-		args []string
-		id   string
+		id                string
+		exitCode          int
+		containerExitCode int
 	)
 
 	BeforeEach(func() {
+		containerExitCode = 13
 		id = randomDockerName()
-		args = []string{"run", "--name", id, "-d", Image, "sh", "-c", "sleep 10 && exit 13"}
-		runDockerCommand(0, args...)
-
+		_, _, exitCode = DockerRun("--name", id, "-d", Image, "sh", "-c",
+			fmt.Sprintf("sleep 10 && exit %d", containerExitCode))
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {
@@ -38,13 +42,11 @@ var _ = Describe("attach", func() {
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
-	Describe("attach with docker", func() {
-		Context("check attach functionality", func() {
-			It("should attach exit code", func() {
-				Skip("Issue https://github.com/clearcontainers/runtime/issues/363")
-				args = []string{"attach", id}
-				runDockerCommand(13, args...)
-			})
+	Context("check attach functionality", func() {
+		It("should attach exit code", func() {
+			Skip("Issue https://github.com/clearcontainers/runtime/issues/363")
+			_, _, exitCode = DockerAttach(id)
+			Expect(exitCode).To(Equal(containerExitCode))
 		})
 	})
 })

--- a/integration/docker/attach_test.go
+++ b/integration/docker/attach_test.go
@@ -34,8 +34,8 @@ var _ = Describe("attach", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("attach with docker", func() {

--- a/integration/docker/commit_test.go
+++ b/integration/docker/commit_test.go
@@ -33,8 +33,8 @@ var _ = Describe("commit", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("commit with docker", func() {

--- a/integration/docker/commit_test.go
+++ b/integration/docker/commit_test.go
@@ -20,16 +20,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("commit", func() {
+var _ = Describe("docker commit", func() {
 	var (
-		args []string
-		id   string
+		id       string
+		exitCode int
+		stdout   string
 	)
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-td", "--name", id, Image, "sh"}
-		runDockerCommand(0, args...)
+		_, _, exitCode = DockerRun("-td", "--name", id, Image, "sh")
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {
@@ -37,19 +38,22 @@ var _ = Describe("commit", func() {
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
-	Describe("commit with docker", func() {
-		Context("commit a container with new configurations", func() {
-			It("should have the new configurations", func() {
-				imageName := "test/container-test"
-				args = []string{"commit", "-m", "test_commit", id, imageName}
-				runDockerCommand(0, args...)
-				stdout := runDockerCommand(0, "images")
-				Expect(stdout).To(ContainSubstring(imageName))
-				args = []string{"rmi", imageName}
-				runDockerCommand(0, args...)
-				stdout = runDockerCommand(0, "images")
-				Expect(stdout).NotTo(ContainSubstring(imageName))
-			})
+	Context("commit a container with new configurations", func() {
+		It("should have the new configurations", func() {
+			imageName := "test/container-test"
+			_, _, exitCode = DockerCommit("-m", "test_commit", id, imageName)
+			Expect(exitCode).To(Equal(0))
+
+			stdout, _, exitCode = DockerImages()
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).To(ContainSubstring(imageName))
+
+			_, _, exitCode = DockerRmi(imageName)
+			Expect(exitCode).To(Equal(0))
+
+			stdout, _, exitCode = DockerImages()
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).NotTo(ContainSubstring(imageName))
 		})
 	})
 })

--- a/integration/docker/cp_test.go
+++ b/integration/docker/cp_test.go
@@ -15,12 +15,13 @@
 package docker
 
 import (
-	. "github.com/clearcontainers/tests"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"os"
 	"path"
+
+	. "github.com/clearcontainers/tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("cp", func() {
@@ -36,8 +37,8 @@ var _ = Describe("cp", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("cp with docker", func() {

--- a/integration/docker/create_test.go
+++ b/integration/docker/create_test.go
@@ -20,10 +20,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("create", func() {
+var _ = Describe("docker create", func() {
 	var (
-		args []string
-		id   string
+		id       string
+		exitCode int
+		stdout   string
 	)
 
 	AfterEach(func() {
@@ -31,16 +32,15 @@ var _ = Describe("create", func() {
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
-	Describe("create with docker", func() {
-		Context("check create functionality", func() {
-			It("create a container", func() {
-				id = randomDockerName()
-				args = []string{"create", "-t", "--name", id, Image}
-				runDockerCommand(0, args...)
-				args = []string{"ps", "--filter", "status=created"}
-				stdout := runDockerCommand(0, args...)
-				Expect(stdout).To(ContainSubstring(id))
-			})
+	Context("check create functionality", func() {
+		It("create a container", func() {
+			id = randomDockerName()
+			_, _, exitCode = DockerCreate("-t", "--name", id, Image)
+			Expect(exitCode).To(Equal(0))
+
+			stdout, _, exitCode = DockerPs("--filter", "status=created")
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).To(ContainSubstring(id))
 		})
 	})
 })

--- a/integration/docker/create_test.go
+++ b/integration/docker/create_test.go
@@ -27,8 +27,8 @@ var _ = Describe("create", func() {
 	)
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("create with docker", func() {

--- a/integration/docker/env_test.go
+++ b/integration/docker/env_test.go
@@ -20,10 +20,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("env", func() {
+var _ = Describe("docker env", func() {
 	var (
-		args []string
-		id   string
+		id       string
+		hostname string
+		stdout   string
+		exitCode int
 	)
 
 	AfterEach(func() {
@@ -31,17 +33,15 @@ var _ = Describe("env", func() {
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
-	Describe("check env", func() {
-		Context("check that required env variables are set", func() {
-			It("should have path, hostname, home", func() {
-				id = randomDockerName()
-				hostname := "container"
-				args = []string{"run", "--name", id, "-h", hostname, Image, "env"}
-				stdout := runDockerCommand(0, args...)
-				Expect(stdout).To(ContainSubstring("PATH"))
-				Expect(stdout).To(ContainSubstring("HOME"))
-				Expect(stdout).To(ContainSubstring("HOSTNAME=" + hostname))
-			})
+	Context("check that required env variables are set", func() {
+		It("should have path, hostname, home", func() {
+			id = randomDockerName()
+			hostname = "container"
+			stdout, _, exitCode = DockerRun("--name", id, "-h", hostname, Image, "env")
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).To(ContainSubstring("PATH"))
+			Expect(stdout).To(ContainSubstring("HOME"))
+			Expect(stdout).To(ContainSubstring("HOSTNAME=" + hostname))
 		})
 	})
 })

--- a/integration/docker/env_test.go
+++ b/integration/docker/env_test.go
@@ -27,8 +27,8 @@ var _ = Describe("env", func() {
 	)
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("check env", func() {

--- a/integration/docker/exec_test.go
+++ b/integration/docker/exec_test.go
@@ -33,8 +33,8 @@ var _ = Describe("exec", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("exec with docker", func() {

--- a/integration/docker/export_test.go
+++ b/integration/docker/export_test.go
@@ -15,11 +15,12 @@
 package docker
 
 import (
+	"io/ioutil"
+	"os"
+
 	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"os"
 )
 
 var _ = Describe("export", func() {
@@ -35,8 +36,8 @@ var _ = Describe("export", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("export with docker", func() {

--- a/integration/docker/inspect_test.go
+++ b/integration/docker/inspect_test.go
@@ -41,8 +41,8 @@ var _ = Describe("inspect", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	DescribeTable("inspect with docker",

--- a/integration/docker/kill_test.go
+++ b/integration/docker/kill_test.go
@@ -27,8 +27,8 @@ var _ = Describe("kill", func() {
 	)
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("kill with docker", func() {
@@ -37,11 +37,11 @@ var _ = Describe("kill", func() {
 				id = randomDockerName()
 				args = []string{"run", "-td", "--name", id, Image, "sh"}
 				runDockerCommand(0, args...)
-				Expect(ContainerRunning(id)).To(BeTrue())
+				Expect(IsRunningDockerContainer(id)).To(BeTrue())
 				args = []string{"kill", id}
 				stdout := runDockerCommand(0, args...)
 				Expect(stdout).To(ContainSubstring(id))
-				Expect(ContainerRunning(id)).To(BeFalse())
+				Expect(IsRunningDockerContainer(id)).To(BeFalse())
 			})
 		})
 	})

--- a/integration/docker/load_test.go
+++ b/integration/docker/load_test.go
@@ -15,11 +15,12 @@
 package docker
 
 import (
+	"io/ioutil"
+	"os"
+
 	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"os"
 )
 
 var _ = Describe("load", func() {
@@ -36,8 +37,8 @@ var _ = Describe("load", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 		args = []string{"rmi", imageName}
 		runDockerCommand(0, args...)
 	})

--- a/integration/docker/logs_test.go
+++ b/integration/docker/logs_test.go
@@ -15,10 +15,11 @@
 package docker
 
 import (
+	"time"
+
 	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"time"
 )
 
 var _ = Describe("logs", func() {
@@ -36,8 +37,8 @@ var _ = Describe("logs", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("logs with docker", func() {

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -29,9 +29,9 @@ func randomDockerName() string {
 func runDockerCommand(expectedExitCode int, args ...string) string {
 	cmd := NewCommand(Docker, args...)
 	Expect(cmd).ToNot(BeNil())
-	LogIfFail(cmd.Stderr.String())
-	Expect(cmd.Run()).To(Equal(expectedExitCode))
-	return cmd.Stdout.String()
+	stdout, _, exitCode := cmd.Run()
+	Expect(exitCode).To(Equal(expectedExitCode))
+	return stdout
 }
 
 func TestIntegration(t *testing.T) {
@@ -42,7 +42,8 @@ func TestIntegration(t *testing.T) {
 	}
 
 	for _, i := range images {
-		if !ImagePull(i) {
+		_, _, exitCode := DockerPull(i)
+		if exitCode != 0 {
 			t.Fatalf("failed to pull docker image: %s\n", i)
 		}
 	}

--- a/integration/docker/port_test.go
+++ b/integration/docker/port_test.go
@@ -33,8 +33,8 @@ var _ = Describe("port", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("port with docker", func() {

--- a/integration/docker/restart_test.go
+++ b/integration/docker/restart_test.go
@@ -33,18 +33,18 @@ var _ = Describe("restart", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("restart with docker", func() {
 		Context("restart a container", func() {
 			It("should be running", func() {
-				Expect(ContainerStop(id)).To(BeTrue())
-				Expect(ContainerRunning(id)).To(BeFalse())
+				Expect(StopDockerContainer(id)).To(BeTrue())
+				Expect(IsRunningDockerContainer(id)).To(BeFalse())
 				args = []string{"restart", id}
 				runDockerCommand(0, args...)
-				Expect(ContainerRunning(id)).To(BeTrue())
+				Expect(IsRunningDockerContainer(id)).To(BeTrue())
 			})
 		})
 	})

--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -39,7 +39,7 @@ var _ = Describe("run", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	DescribeTable("container with docker",
@@ -49,8 +49,7 @@ var _ = Describe("run", func() {
 			command := NewCommand(Docker, args...)
 			Expect(command).NotTo(BeNil())
 
-			exitCode := command.Run()
-			LogIfFail(command.Stderr.String())
+			_, _, exitCode := command.Run()
 
 			Expect(expectedExitCode).To(Equal(exitCode))
 		},
@@ -75,8 +74,8 @@ var _ = Describe("run", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	DescribeTable("container with docker",
@@ -86,14 +85,13 @@ var _ = Describe("run", func() {
 			command := NewCommand(Docker, args...)
 			Expect(command).NotTo(BeNil())
 
-			exitCode := command.Run()
-			LogIfFail(command.Stderr.String())
+			_, _, exitCode := command.Run()
 
 			Expect(exitCode).To(BeZero())
 
-			Expect(ContainerStatus(id)).To(Equal(expectedStatus))
+			Expect(StatusDockerContainer(id)).To(Equal(expectedStatus))
 
-			Expect(ContainerExists(id)).To(BeTrue())
+			Expect(ExistDockerContainer(id)).To(BeTrue())
 		},
 		Entry("in background and interactive", "-di", "Up"),
 		Entry("in background, interactive and with a tty", "-dit", "Up"),

--- a/integration/docker/tag_test.go
+++ b/integration/docker/tag_test.go
@@ -34,8 +34,8 @@ var _ = Describe("tag", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 		args = []string{"rmi", tagName}
 		runDockerCommand(0, args...)
 	})

--- a/integration/docker/terminal_test.go
+++ b/integration/docker/terminal_test.go
@@ -31,8 +31,8 @@ var _ = Describe("terminal", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("terminal with docker", func() {

--- a/integration/docker/user_test.go
+++ b/integration/docker/user_test.go
@@ -31,8 +31,8 @@ var _ = Describe("user", func() {
 	})
 
 	AfterEach(func() {
-		Expect(ContainerRemove(id)).To(BeTrue())
-		Expect(ContainerExists(id)).NotTo(BeTrue())
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
 	Describe("set user with docker", func() {

--- a/integration/docker/volume_test.go
+++ b/integration/docker/volume_test.go
@@ -15,12 +15,13 @@
 package docker
 
 import (
-	. "github.com/clearcontainers/tests"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"os"
 	"path"
+
+	. "github.com/clearcontainers/tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("volume", func() {
@@ -55,10 +56,10 @@ var _ = Describe("volume", func() {
 				args = []string{"run", "--name", id2, "-t", "-v", volumeName + ":" + containerPath, Image, "ls", containerPath}
 				stdout := runDockerCommand(0, args...)
 				Expect(stdout).To(ContainSubstring(fileTest))
-				Expect(ContainerRemove(id)).To(BeTrue())
-				Expect(ContainerExists(id)).NotTo(BeTrue())
-				Expect(ContainerRemove(id2)).To(BeTrue())
-				Expect(ContainerExists(id2)).NotTo(BeTrue())
+				Expect(RemoveDockerContainer(id)).To(BeTrue())
+				Expect(ExistDockerContainer(id)).NotTo(BeTrue())
+				Expect(RemoveDockerContainer(id2)).To(BeTrue())
+				Expect(ExistDockerContainer(id2)).NotTo(BeTrue())
 				args = []string{"volume", "rm", volumeName}
 				runDockerCommand(0, args...)
 				args = []string{"volume", "ls"}
@@ -79,8 +80,8 @@ var _ = Describe("volume", func() {
 				args = []string{"run", "--name", id, "-v", testFile + ":/root/" + fileTest, Image, "ls", "/root/"}
 				stdout := runDockerCommand(0, args...)
 				Expect(stdout).To(ContainSubstring(fileTest))
-				Expect(ContainerRemove(id)).To(BeTrue())
-				Expect(ContainerExists(id)).NotTo(BeTrue())
+				Expect(RemoveDockerContainer(id)).To(BeTrue())
+				Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 				args = []string{"volume", "rm", testFile}
 				runDockerCommand(0, args...)
 				args = []string{"volume", "ls"}


### PR DESCRIPTION
with this wrapper make tests will be easier because the user
will not be worry about the timeouts neither writing incorrectly
the name of the commands

Fixes #374

Signed-off-by: Julio Montes <julio.montes@intel.com>