### PR TITLE
CI: Remove user as project approver

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -36,7 +36,6 @@ groups:
     users:
       - chavafg
       - devimc
-      - dlespiau
       - GabyCT
       - grahamwhaley
 

--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@ reviewers:
 approvers:
 - chavafg
 - devimc
-- dlespiau
 - GabyCT
 - grahamwhaley
 


### PR DESCRIPTION
Remove user dlespiau as a project approver as he is no longer a core
maintainer.

Fixes #376.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>