### PR TITLE
functional: fix container.Exist method

### DIFF
--- a/container.go
+++ b/container.go
@@ -269,7 +269,7 @@ func (c *Container) Cleanup() error {
 // - the VM is running (qemu)
 // else false is returned
 func (c *Container) Exist() bool {
-	return c.isListed() || c.isWorkloadRunning() || c.isVMRunning()
+	return c.isListed() || c.isWorkloadRunning() || IsVMRunning(*c.ID)
 }
 
 func (c *Container) isListed() bool {
@@ -300,9 +300,4 @@ func (c *Container) isWorkloadRunning() bool {
 	}
 
 	return true
-}
-
-func (c *Container) isVMRunning() bool {
-	// FIXME: find a way to check if the VM is still running
-	return false
 }


### PR DESCRIPTION
this patch uses the function IsVMRunning that is defined in vm.go
to detect if a VM is running and remove the method container.isVmRunning
hece it is no more needed

fixes #384

Signed-off-by: Julio Montes <julio.montes@intel.com>