### PR TITLE
tests: Add Dockerfile for docker integration swarm tests

### DIFF
--- a/Dockerfiles/SwarmTest/Dockerfile.nginx
+++ b/Dockerfiles/SwarmTest/Dockerfile.nginx
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# NGINX Dockerfile for Swarm Tests for Clear Containers
+
+# XXX: named version
+FROM debian
+
+ENV NGINX_VERSION 1.13.1-1~stretch
+ENV NJS_VERSION   1.13.1.0.1.10-1~stretch
+
+RUN apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 \
+	&& \
+	NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
+	found=''; \
+	for server in \
+		ha.pool.sks-keyservers.net \
+		hkp://keyserver.ubuntu.com:80 \
+		hkp://p80.pool.sks-keyservers.net:80 \
+		pgp.mit.edu \
+	; do \
+		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
+		apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+	done; \
+	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
+	apt-get remove --purge -y gnupg1 && apt-get -y --purge autoremove && rm -rf /var/lib/apt/lists/* \
+	&& echo "deb http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list \
+	&& apt-get update \
+	&& apt-get install --no-install-recommends --no-install-suggests -y \
+						nginx=${NGINX_VERSION} \
+						nginx-module-xslt=${NGINX_VERSION} \
+						nginx-module-geoip=${NGINX_VERSION} \
+						nginx-module-image-filter=${NGINX_VERSION} \
+						nginx-module-njs=${NJS_VERSION} \
+						gettext-base \
+	&& rm -rf /var/lib/apt/lists/*
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 80
+
+STOPSIGNAL SIGTERM
+
+CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/bash"]

--- a/Dockerfiles/SwarmTest/README.md
+++ b/Dockerfiles/SwarmTest/README.md
@@ -1,0 +1,17 @@
+# NGINX image for Intel® Clear Containers swarm tests
+
+To build the nginx image used in our swarm tests, 
+follow these steps:
+
+1. Build the nginx image:
+
+```
+$ docker build -t $name -f Dockerfile.nginx .
+```
+
+2. Verify the nginx image:
+
+```
+$ docker run -ti $name bash
+
+```


### PR DESCRIPTION
Add Nginx Dockerfile that enables the ip command that will be
used in swarm integration tests

Fixes #387

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>