### PR TITLE
localCI: add options to test revisions and repos in parallel

### DIFF
--- a/cmd/localCI/README.rst
+++ b/cmd/localCI/README.rst
@@ -63,7 +63,9 @@ The configuration file follows the syntax defined by the `Tom's Obvious, Minimal
 Keys
 ~~~~
 
-- ``runTestsInParallel [bool] (optional)``: specify whether the tests can run in parallel. By default this value is ``false``. If **localCI** is running as a tool the value is ignored.
+- ``testReposInParallel [bool] (optional)``: specify whether two or more repositories can be tested in parallel. By default this value is ``false``.
+- ``testRevisionsInParallel [bool] (optional)``: specify whether two or more revisions (pull requests and master branch) of one repository can be tested in parallel.
+By default this value is ``false``. If **localCI** is running as a tool this key is ignored.
 
 Sections
 ~~~~~~~~

--- a/cmd/localCI/config.go
+++ b/cmd/localCI/config.go
@@ -22,8 +22,9 @@ import (
 )
 
 type config struct {
-	RunTestsInParallel bool
-	Repo               []Repo
+	TestReposInParallel     bool
+	TestRevisionsInParallel bool
+	Repo                    []Repo
 }
 
 const (
@@ -47,7 +48,8 @@ func newConfig(file string) (*config, error) {
 
 	// set default values
 	c := config{
-		RunTestsInParallel: false,
+		TestReposInParallel:     false,
+		TestRevisionsInParallel: false,
 		Repo: []Repo{
 			{
 				MasterBranch: defaultMasterBranch,

--- a/cmd/localCI/main.go
+++ b/cmd/localCI/main.go
@@ -118,7 +118,8 @@ func main() {
 		}
 		ciLog.Debugf("configuration %+v", config)
 
-		runTestsInParallel = config.RunTestsInParallel
+		testReposInParallel = config.TestReposInParallel
+		testRevisionsInParallel = config.TestRevisionsInParallel
 
 		context.App.Metadata = map[string]interface{}{
 			"repos": config.Repo,


### PR DESCRIPTION
this patch adds two options to test revisions and repos in parallel

fixes #390

Signed-off-by: Julio Montes <julio.montes@intel.com>