### PR TITLE
localCI: use the proper way to start go routines in a loop

### DIFF
--- a/cmd/localCI/main.go
+++ b/cmd/localCI/main.go
@@ -41,7 +41,10 @@ func loop(repos []Repo) error {
 		}
 
 		wg.Add(1)
-		go r.loop()
+		go func(repo Repo) {
+			repo.loop()
+			wg.Done()
+		}(r)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
according with https://github.com/golang/go/wiki/CommonMistakes
the proper way to start go routines in a loop is:

```
for val := range values {
	go func(val interface{}) {
		fmt.Println(val)
	}(val)
}
```

this patch fixes the main.loop method to avoid issues starting
go routines

fixes #389

Signed-off-by: Julio Montes <julio.montes@intel.com>