### PR TITLE
localCI: Fix LOCALCI_REPO_SLUG var format

### DIFF
--- a/cmd/localCI/cvr.go
+++ b/cmd/localCI/cvr.go
@@ -103,6 +103,9 @@ type CVR interface {
 	// getProjectSlug returns the domain, owner and repo name separated by '/'
 	getProjectSlug() string
 
+	// getRepoSlug returns the owner and the repo name separated by '/'
+	getRepoSlug() string
+
 	// getLatestPullRequestComment returns the latest comment of a specific
 	// user in the specific pr. If user is an empty string then any user
 	// could be the author of the latest comment. If body is an empty

--- a/cmd/localCI/github.go
+++ b/cmd/localCI/github.go
@@ -89,6 +89,11 @@ func (g *Github) getProjectSlug() string {
 	return fmt.Sprintf("%s/%s/%s", githubDomain, g.owner, g.repo)
 }
 
+// getRepoSlug returns the owner and the repo name separated by '/'
+func (g *Github) getRepoSlug() string {
+	return fmt.Sprintf("%s/%s", g.owner, g.repo)
+}
+
 // getPullRequestCommits returns the commits of a pull request
 func (g *Github) getPullRequestCommits(pr int) ([]repoCommit, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeoutShortRequest)

--- a/cmd/localCI/repo.go
+++ b/cmd/localCI/repo.go
@@ -210,7 +210,7 @@ func (r *Repo) setupEnvars() error {
 	// add environment variables
 	r.env = os.Environ()
 	r.env = append(r.env, defaultEnv...)
-	repoSlug := fmt.Sprintf("LOCALCI_REPO_SLUG=%s", r.cvr.getProjectSlug())
+	repoSlug := fmt.Sprintf("LOCALCI_REPO_SLUG=%s", r.cvr.getRepoSlug())
 	r.env = append(r.env, repoSlug)
 
 	return nil


### PR DESCRIPTION
Fetchtool uses LOCALCI_REPO_SLUG var, this var is
set by localCI, then fetchtool expects 2 arguments
after split LOCALCI_REPO_SLUG with “/” as delimiter,
however localCI exports this var with github domain
as extra information.
This commit fixes the correct format var for fetchtool.

Fixes: #394

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>