### PR TITLE
tests: fix IsVMRunning function

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -29,7 +29,16 @@ var errFound = errors.New("found")
 // IsVMRunning looks in /proc for a hypervisor process that contains
 // the containerID in its command line
 func IsVMRunning(containerID string) bool {
-	err := filepath.Walk(procPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(procPath, func(path string, _ os.FileInfo, _ error) error {
+		if path == "" {
+			return filepath.SkipDir
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return filepath.SkipDir
+		}
+
 		if !info.IsDir() {
 			return filepath.SkipDir
 		}


### PR DESCRIPTION
to avoid crashes in IsVMRunning function we shouldn't use
the reference to FileInfo that filepath.Walk provides

fixes #396

Signed-off-by: Julio Montes <julio.montes@intel.com>