### PR TITLE
tests: implement container.Teardown function

### DIFF
--- a/container.go
+++ b/container.go
@@ -253,9 +253,29 @@ func (c *Container) RemoveOption(option string) error {
 	return nil
 }
 
-// Cleanup removes files and directories created by the container
-// returns an error if a file or directory can not be removed
-func (c *Container) Cleanup() error {
+// Teardown deletes the container if it is running,
+// ensures the container is not running and removes any
+// file created by the container
+func (c *Container) Teardown() error {
+	var cid string
+
+	if c.ID != nil {
+		cid = *c.ID
+	}
+
+	// if container exist then delete it
+	if c.Exist() {
+		_, stderr, exitCode := c.Delete(true)
+		if exitCode != 0 {
+			return fmt.Errorf("failed to delete container %s %s", cid, stderr)
+		}
+
+		// if container still exist then fail
+		if c.Exist() {
+			return fmt.Errorf("unable to delete container %s", cid)
+		}
+	}
+
 	if c.Bundle != nil {
 		return c.Bundle.Remove()
 	}

--- a/functional/exec_test.go
+++ b/functional/exec_test.go
@@ -74,10 +74,7 @@ var _ = Describe("exec", func() {
 	})
 
 	AfterEach(func() {
-		Expect(container.Exist()).Should(BeTrue())
-		_, _, exitCode = container.Delete(true)
-		Expect(exitCode).Should(Equal(0))
-		Expect(container.Cleanup()).Should(Succeed())
+		Expect(container.Teardown()).To(Succeed())
 	})
 
 	DescribeTable("container",

--- a/functional/run_test.go
+++ b/functional/run_test.go
@@ -45,8 +45,7 @@ var _ = Describe("run", func() {
 	})
 
 	AfterEach(func() {
-		Ω(container.Exist()).ShouldNot(BeTrue())
-		Ω(container.Cleanup()).Should(Succeed())
+		Expect(container.Teardown()).To(Succeed())
 	})
 
 	DescribeTable("container",
@@ -79,8 +78,7 @@ var _ = Describe("run", func() {
 	})
 
 	AfterEach(func() {
-		Ω(container.Exist()).ShouldNot(BeTrue())
-		Ω(container.Cleanup()).Should(Succeed())
+		Expect(container.Teardown()).To(Succeed())
 	})
 
 	DescribeTable("container",


### PR DESCRIPTION
this patch implements container.Teardown function and
removes container.Cleanup function, this function can be
useful in the ```AfterEach``` of each test to ensure the
container is destroyed and no resources are leaked

fixes #397

Signed-off-by: Julio Montes <julio.montes@intel.com>