### PR TITLE
ci: Increase test timeout from 5 to 15 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 CC_RUNTIME ?= cc-runtime
 
 # The time limit in seconds for each test
-TIMEOUT ?= 5
+TIMEOUT ?= 15
 
 CRIO_REPO_PATH="${GOPATH}/src/github.com/kubernetes-incubator/cri-o"
 crio:


### PR DESCRIPTION
The 5 seconds timeout is appropriate if the tests run on baremetal,
but according to recent changes on QEMU parameters if running in a
nested environment, the tests have been slowed down by disabling fast
MMIO access previously performed by virtio 1.0.

And given the fact that our CI runs on a VMM, we cannot afford this
timeout of 5 seconds. Moving this timeout to 15 seconds makes the
tests passing even when run inside a VM.

Fixes #412