### PR TITLE
 localCI: do not re-test a pull request failed

### DIFF
--- a/cmd/localCI/language.go
+++ b/cmd/localCI/language.go
@@ -54,6 +54,21 @@ type languageConfig struct {
 	env []string
 }
 
+// cleanup removes working and temporal directory
+func (l *languageConfig) cleanup() error {
+	err := os.RemoveAll(l.workingDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove the working directory '%s' %s", l.workingDir, err)
+	}
+
+	err = os.RemoveAll(l.tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove the temporal directory '%s' %s", l.tempDir, err)
+	}
+
+	return nil
+}
+
 var supportedLanguages = map[string]newLanguageFunc{
 	"Go": newGoLanguage,
 }


### PR DESCRIPTION
localCI re-tests a pull request failed even if it has not
changed (no new commits), this is a wrong behavior because a
pull request must be re-tested only when it has
changed (new commits).

fixes #416

Signed-off-by: Julio Montes <julio.montes@intel.com>