### PR TITLE
kubernetes: Add setup, init scripts and nginx test

### DIFF
--- a/.ci/data/crio.service
+++ b/.ci/data/crio.service
@@ -4,6 +4,8 @@ Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
 ExecStart=/usr/local/bin/crio --debug
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -32,11 +32,13 @@ make
 sudo -E PATH=$PATH sh -c "make install"
 sudo -E PATH=$PATH sh -c "make install.config"
 
+containers_config_path="/etc/containers"
+echo "Copy containers policy from CRI-O repo to $containers_config_path"
+sudo mkdir -p "$containers_config_path"
+sudo cp test/policy.json "$containers_config_path"
+
 echo "Setup cc-runtime as the runtime to use"
 sudo sed -i.bak 's/\/usr\/bin\/runc/\/usr\/local\/bin\/cc-runtime/g' /etc/crio/crio.conf
-
-echo "Setup aufs as the storage driver"
-sudo sed -i.bak 's/storage_driver = \"\"/storage_driver = \"aufs\"/g' /etc/crio/crio.conf
 
 popd
 

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -148,11 +148,13 @@ elif [ "$VERSION_ID" == "16.04" ]; then
 	sudo -E apt update
 	sudo -E apt install -y libostree-dev
 
-	echo "Install Docker"
-	docker_url="https://download.docker.com/linux/ubuntu"
-	sudo -E apt install -y apt-transport-https ca-certificates
-	sudo -E add-apt-repository "deb [arch=amd64] ${docker_url} $(lsb_release -cs) stable"
-	curl -fsSL "${docker_url}/gpg" | sudo -E apt-key add -
-	sudo -E apt update
-	sudo -E apt install -y docker-ce
+	if ! command -v docker > /dev/null; then
+		echo "Install Docker"
+		docker_url="https://download.docker.com/linux/ubuntu"
+		sudo -E apt install -y apt-transport-https ca-certificates
+		sudo -E add-apt-repository "deb [arch=amd64] ${docker_url} $(lsb_release -cs) stable"
+		curl -fsSL "${docker_url}/gpg" | sudo -E apt-key add -
+		sudo -E apt update
+		sudo -E apt install -y docker-ce
+	fi
 fi

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBECONFIG=/etc/kubernetes/admin.conf
+sudo -E kubeadm reset
+sudo systemctl stop kubelet
+sudo systemctl stop docker
+for ctr in $(sudo crioctl ctr list | grep ^ID | cut -c5-); do
+	sudo crioctl ctr stop --id "$ctr"
+	sudo crioctl ctr remove --id "$ctr"
+done
+for pod in $(sudo crioctl pod list | grep ^ID | cut -c5-); do
+	sudo crioctl pod stop --id "$pod"
+	sudo crioctl pod remove --id "$pod"
+done
+
+sudo systemctl stop crio
+sudo rm -rf /var/lib/cni/*
+sudo rm -rf /var/run/crio/*
+sudo rm -rf /var/log/crio/*
+sudo rm -rf /var/lib/kubelet/*
+sudo rm -rf /run/flannel/*
+sudo rm -rf /etc/cni/net.d/*
+
+sudo umount /tmp/hyper/shared/pods/*/*/rootfs \
+			/tmp/tmp*/crio/overlay2/*/merged \
+			/tmp/hyper/shared/pods/*/*/rootfs \
+			/run/netns/cni-* \
+			/tmp/tmp*/crio-run/overlay2-containers/*/userdata/shm \
+			/tmp/tmp*/crio/overlay2 \
+			/tmp/hyper/shared/pods/*/*-resolv.conf \
+			/var/lib/containers/storage/overlay2
+
+sudo rm -rf /var/lib/virtcontainers/pods/*
+sudo rm -rf /var/run/virtcontainers/pods/*
+sudo rm -rf /var/lib/containers/storage/*
+sudo rm -rf /var/run/containers/storage/*
+
+sudo ip link set dev cni0 down
+sudo ip link set dev cbr0 down
+sudo ip link set dev flannel.1 down
+sudo ip link set dev docker0 down
+sudo ip link del cni0
+sudo ip link del cbr0
+sudo ip link del flannel.1
+sudo ip link del docker0
+
+sudo systemctl start docker
+sudo systemctl start crio
+sudo systemctl restart cc-proxy

--- a/integration/kubernetes/data/kube-flannel-rbac.yml
+++ b/integration/kubernetes/data/kube-flannel-rbac.yml
@@ -1,0 +1,40 @@
+# This file was pulled from:
+# https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378)
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system

--- a/integration/kubernetes/data/kube-flannel.yml
+++ b/integration/kubernetes/data/kube-flannel.yml
@@ -1,0 +1,95 @@
+# This file was pulled from:
+# https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378)
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-system
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "type": "flannel",
+      "delegate": {
+        "isDefaultGateway": true
+      }
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.8.0-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.8.0-amd64
+        command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/lib.sh"
+
+sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+sudo -E kubectl get nodes
+sudo -E kubectl get pods
+sudo -E kubectl create -f "${SCRIPT_PATH}/data/kube-flannel-rbac.yml"
+sudo -E kubectl create --namespace kube-system -f "${SCRIPT_PATH}/data/kube-flannel.yml"
+
+# The kube-dns pod usually takes around 30 seconds to get ready
+# This instruction will wait until it is up and running, so we can
+# start creating our containers.
+dns_wait_time=60
+sleep_time=5
+cmd="sudo -E kubectl get pods --all-namespaces | grep dns | grep Running"
+waitForProcess "$dns_wait_time" "$sleep_time" "$cmd"

--- a/integration/kubernetes/lib.sh
+++ b/integration/kubernetes/lib.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains functions that can be used in the scripts and/or
+# tests for kubernets and Clear Containers.
+
+function waitForProcess(){
+	wait_time="$1"
+	sleep_time="$2"
+	cmd="$3"
+	while [ "$wait_time" -gt 0 ]; do
+		if eval "$cmd"; then
+			return 0
+		else
+			sleep "$sleep_time"
+			wait_time=$((wait_time-sleep_time))
+		fi
+	done
+	return 1
+}

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# *-*- Mode: sh; sh-basic-offset: 8; indent-tabs-mode: nil -*-*
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+
+setup() {
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+	master=$(hostname)
+	sudo -E kubectl taint nodes "$master" node-role.kubernetes.io/master:NoSchedule-
+}
+
+@test "Verify nginx connectivity between pods" {
+	service_name="nginx"
+	wait_time=20
+	sleep_time=3
+	output_file=$(mktemp)
+	echo $output_file
+	cmd="sudo -E kubectl get pods | grep $service_name | grep Running"
+	sudo -E kubectl run "$service_name" --image="$service_name" --replicas=2
+	sudo -E kubectl expose deployment "$service_name" --port=80
+	sudo -E kubectl get svc,pod
+	# Wait for nginx service to come up
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+	run bash -c "sudo -E kubectl run busybox --rm -ti --restart=Never \
+		--image=busybox -- wget --timeout=1 $service_name > $output_file"
+	[ "$status" -eq 0 ]
+	grep "index.html" "$output_file"
+}
+
+teardown() {
+	rm "$output_file"
+	sudo -E kubectl delete deployment "$service_name"
+}

--- a/integration/kubernetes/setup.sh
+++ b/integration/kubernetes/setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
+echo "Install Kubernetes"
+sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
+EOF"
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo -E apt update
+sudo -E apt install -y docker.io kubelet=1.6.7-00 kubeadm=1.6.7-00 kubectl=1.6.7-00
+sudo -E apt-mark hold kubelet kubeadm kubectl
+
+echo "Install Clear Containers, including dependencies"
+pushd "${SCRIPT_PATH}/../../.ci"
+./setup.sh
+popd
+
+echo "Install runc for CRI-O"
+go get -d github.com/opencontainers/runc
+pushd "${GOPATH}/src/github.com/opencontainers/runc"
+make
+sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
+popd
+
+crio_config_file="/etc/crio/crio.conf"
+echo "Set runc as default runtime in CRI-O for trusted workloads"
+sudo sed -i 's/^runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
+
+echo "Set Clear containers as default runtime in CRI-O for untrusted workloads"
+sudo sed -i 's/default_workload_trust = "trusted"/default_workload_trust = "untrusted"/' "$crio_config_file"
+sudo sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/local\/bin\/cc-runtime"/' "$crio_config_file"
+
+echo "Modify kubelet systemd configuration to use CRI-O"
+k8s_systemd_file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+sudo sed -i '/KUBELET_AUTHZ_ARGS/a Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=/var/run/crio.sock --runtime-request-timeout=30m"' "$k8s_systemd_file"
+sudo systemctl daemon-reload


### PR DESCRIPTION
This PR:
1. updates the CRI-O configuration to support kubernetes.
2. Install Kubernetes and its dependencies 
3. Configures kubernetes to use CRI-O with clear containers for untrusted workloads