### PR TITLE
ci: update CRI-O version used for testing

### DIFF
--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,5 +1,5 @@
 # Well known working crio tag/commit/branch
-crio_version=065960386fce7088bab3fc22af44ebbbf75d3641
+crio_version=959aab4fd5dbc315ca2dc84a90599c2108756a2c
 
 # Kernel Version to use on recent Linux Distros
 kernel_clear_release=16680


### PR DESCRIPTION
The new commit of CRI-O has been tested and works well with
Clear Containers.

Fixes #424.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>