### PR TITLE
integration/docker: re-implement docker user tests

### DIFF
--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -22,6 +22,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	shouldFail    = true
+	shouldNotFail = false
+)
+
 func randomDockerName() string {
 	return RandID(30)
 }

--- a/integration/docker/user_test.go
+++ b/integration/docker/user_test.go
@@ -15,15 +15,35 @@
 package docker
 
 import (
+	"fmt"
+	"strings"
+
 	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("user", func() {
+const (
+	withAdditionalGroups    = true
+	withoutAdditionalGroups = false
+)
+
+func asUser(user string, groups bool, fail bool) TableEntry {
+	additionalGroups := []string{"cdrom", "games", "video", "audio"}
+	groupsMsg := fmt.Sprintf(" with additional groups %v", additionalGroups)
+	if !groups {
+		groupsMsg = fmt.Sprintf(" without additional groups")
+		additionalGroups = []string{}
+	}
+
+	return Entry(fmt.Sprintf("as '%s' user%s", user, groupsMsg),
+		user, additionalGroups, fail)
+}
+
+var _ = Describe("users and groups", func() {
 	var (
-		args []string
-		id   string
+		id string
 	)
 
 	BeforeEach(func() {
@@ -31,33 +51,85 @@ var _ = Describe("user", func() {
 	})
 
 	AfterEach(func() {
-		Expect(RemoveDockerContainer(id)).To(BeTrue())
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
-	Describe("set user with docker", func() {
-		Context("run as non-root user", func() {
-			It("should display the non-root user", func() {
-				Skip("Issue https://github.com/clearcontainers/runtime/issues/386")
-				args = []string{"run", "--name", id, "-u", "postgres", AlpineImage, "whoami"}
-				stdout := runDockerCommand(0, args...)
-				Expect(stdout).To(ContainSubstring("postgres"))
-			})
-		})
+	DescribeTable("running container",
+		func(user string, additionalGroups []string, fail bool) {
+			Skip("Issue https://github.com/clearcontainers/runtime/issues/386")
 
-		Context("run as root user", func() {
-			It("should display root user", func() {
-				args = []string{"run", "--name", id, "-u", "root:root", AlpineImage, "whoami"}
-				stdout := runDockerCommand(0, args...)
-				Expect(stdout).To(ContainSubstring("root"))
-			})
-		})
+			cmd := []string{"--name", id, "--rm"}
+			for _, ag := range additionalGroups {
+				cmd = append(cmd, "--group-add", ag)
+			}
+			if user != "" {
+				cmd = append(cmd, "-u", user)
+			}
+			cmd = append(cmd, "postgres", "id")
 
-		Context("run as non-existent user", func() {
-			It("should display an error", func() {
-				args = []string{"run", "--name", id, "-u", "aaaaaaa", AlpineImage, "whoami"}
-				runDockerCommand(125, args...)
-			})
-		})
-	})
+			stdout, stderr, exitCode := DockerRun(cmd...)
+			if fail {
+				Expect(exitCode).ToNot(Equal(0))
+				Expect(stderr).NotTo(BeEmpty())
+				// do not check stdout because container failed
+				return
+			}
+
+			// check exit code and stderr
+			Expect(exitCode).To(Equal(0))
+			Expect(stderr).To(BeEmpty())
+
+			var u, g string
+			if user != "" {
+				ug := strings.Split(user, ":")
+				if len(ug) > 1 {
+					u, g = ug[0], ug[1]
+				} else {
+					u, g = ug[0], ug[0]
+				}
+			}
+
+			// default user and group is root
+			if u == "" {
+				u = "root"
+			}
+			if g == "" {
+				g = "root"
+			}
+
+			fields := strings.Fields(stdout)
+
+			// uid + gid + groups = 3
+			Expect(fields).To(HaveLen(3))
+
+			// check user (uid)
+			Expect(fields[0]).To(ContainSubstring(fmt.Sprintf("(%s)", u)))
+
+			// check group (gid)
+			Expect(fields[1]).To(ContainSubstring(fmt.Sprintf("(%s)", g)))
+
+			// check additional groups
+			for _, ag := range additionalGroups {
+				Expect(fields[2]).To(ContainSubstring(fmt.Sprintf("(%s)", ag)))
+			}
+		},
+		asUser("", withAdditionalGroups, shouldNotFail),
+		asUser("", withoutAdditionalGroups, shouldNotFail),
+		asUser("root", withAdditionalGroups, shouldNotFail),
+		asUser("root", withoutAdditionalGroups, shouldNotFail),
+		asUser("postgres", withAdditionalGroups, shouldNotFail),
+		asUser("postgres", withoutAdditionalGroups, shouldNotFail),
+		asUser(":postgres", withAdditionalGroups, shouldNotFail),
+		asUser(":postgres", withoutAdditionalGroups, shouldNotFail),
+		asUser("postgres:postgres", withAdditionalGroups, shouldNotFail),
+		asUser("postgres:postgres", withoutAdditionalGroups, shouldNotFail),
+		asUser("root:postgres", withAdditionalGroups, shouldNotFail),
+		asUser("root:postgres", withoutAdditionalGroups, shouldNotFail),
+		asUser("nonexistentuser", withAdditionalGroups, shouldFail),
+		asUser("nonexistentuser", withoutAdditionalGroups, shouldFail),
+		asUser("nonexistentuser:postgres", withAdditionalGroups, shouldFail),
+		asUser("nonexistentuser:postgres", withoutAdditionalGroups, shouldFail),
+		asUser(":nonexistentuser", withAdditionalGroups, shouldFail),
+		asUser(":nonexistentuser", withoutAdditionalGroups, shouldFail),
+	)
 })


### PR DESCRIPTION
this patch re-implements docker user tests to verify
that user, group and additional groups are set correctly
inside the container

Fixes #426

Signed-off-by: Julio Montes <julio.montes@intel.com>