### PR TITLE
metrics: storage: Remove RUNTIME default value

### DIFF
--- a/metrics/storage/fio_job.sh
+++ b/metrics/storage/fio_job.sh
@@ -35,7 +35,6 @@ FILE_SIZE="4G"
 FIO_TEST_NAME="io_test"
 NUM_JOBS="1"
 OPERATION="randread"
-RUNTIME="cor"
 TEST_NAME="storage fio test"
 
 # This docker image includes FIO tool.
@@ -158,7 +157,7 @@ function main()
 	init_env
 	create_fio_job
 
-	# Launch container (cor runtime by default)
+	# Launch container
 	output=$(docker run --runtime="$RUNTIME" \
 		"$FIO_IMAGE" bash -c "$FIO_JOB")
 


### PR DESCRIPTION
This value was used for CC 2.x, now this value
is not valid for CC3.0 furthermore it is set by
metrics common lib.

Fixes: #430

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>