### PR TITLE
CI: Specify PATH in `make install` command to install CC components

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -44,6 +44,6 @@ function clone_build_and_install() {
 	clone_and_build $1 $2
 	pushd "${GOPATH}/src/${1}"
 	echo "Install repository ${1}"
-	sudo -E make -e install
+	sudo -E PATH=$PATH make -e install
 	popd
 }


### PR DESCRIPTION
If root user does not have go in its $PATH envar, sudo -E make install will fail.
We need to specify the $PATH of the current user with the sudo command, so it finds go.

Fixes #433.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>