### PR TITLE
tests: Add docker export function at docker.go

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -205,6 +205,11 @@ func DockerBuild(args ...string) (string, string, int) {
 	return runDockerCommand("build", args...)
 }
 
+// DockerExport will export a container’s filesystem as a tar archive
+func DockerExport(args ...string) (string, string, int) {
+	return runDockerCommand("export", args...)
+}
+
 // DockerInfo displays system-wide information
 func DockerInfo() (string, string, int) {
 	return runDockerCommand("info")

--- a/integration/docker/export_test.go
+++ b/integration/docker/export_test.go
@@ -46,8 +46,8 @@ var _ = Describe("export", func() {
 				file, err := ioutil.TempFile(os.TempDir(), "latest.tar")
 				Expect(err).ToNot(HaveOccurred())
 				defer os.Remove(file.Name())
-				args = []string{"export", "--output", file.Name(), id}
-				runDockerCommand(0, args...)
+				_, _, exitCode := DockerExport("--output", file.Name(), id)
+				Expect(exitCode).To(Equal(0))
 				Expect(file.Name()).To(BeAnExistingFile())
 				fileInfo, err := file.Stat()
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Add docker export function at docker.go in order to improve
readability in the integration docker tests

Fixes #435

Signed-off-by: Gabriela Cervantes Tellez <gabriela.cervantes.tellez@intel.com>