### PR TITLE
 integration/docker: re-implement docker kill tests

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -15,6 +15,8 @@
 package tests
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -60,6 +62,19 @@ func StatusDockerContainer(name string) string {
 
 	state := strings.Split(stdout, " ")
 	return state[0]
+}
+
+// ExitCodeDockerContainer returns the container exit code
+func ExitCodeDockerContainer(name string) (int, error) {
+	args := []string{"--format={{.State.ExitCode}}", name}
+
+	stdout, _, exitCode := runDockerCommand("inspect", args...)
+
+	if exitCode != 0 || stdout == "" {
+		return -1, fmt.Errorf("failed to run docker inspect command")
+	}
+
+	return strconv.Atoi(strings.TrimSpace(stdout))
 }
 
 // IsRunningDockerContainer inspects a container

--- a/integration/docker/kill_test.go
+++ b/integration/docker/kill_test.go
@@ -15,34 +15,111 @@
 package docker
 
 import (
+	"fmt"
+	"syscall"
+	"time"
+
 	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("kill", func() {
+const (
+	canBeTrapped    = true
+	cannotBeTrapped = false
+)
+
+func withSignal(signal syscall.Signal, trap bool) TableEntry {
+	expectedExitCode := int(signal)
+	if !trap {
+		// 128 -> command interrupted by a signal
+		expectedExitCode += 128
+	}
+
+	return Entry(fmt.Sprintf("with '%d' signal", signal), signal, expectedExitCode)
+}
+
+func withoutSignal() TableEntry {
+	// 137 = 128(command interrupted by a signal) + 9(SIGKILL)
+	return Entry(fmt.Sprintf("without a signal"), syscall.Signal(0), 137)
+}
+
+func withSignalNotExitCode(signal syscall.Signal) TableEntry {
+	return Entry(fmt.Sprintf("with '%d' signal, don't change the exit code", signal), signal, 0)
+}
+
+var _ = Describe("docker kill", func() {
 	var (
 		args []string
 		id   string
 	)
+
+	BeforeEach(func() {
+		id = randomDockerName()
+	})
 
 	AfterEach(func() {
 		Expect(RemoveDockerContainer(id)).To(BeTrue())
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 
-	Describe("kill with docker", func() {
-		Context("kill a container", func() {
-			It("should assigned exited status", func() {
-				id = randomDockerName()
-				args = []string{"run", "-td", "--name", id, Image, "sh"}
-				runDockerCommand(0, args...)
-				Expect(IsRunningDockerContainer(id)).To(BeTrue())
-				args = []string{"kill", id}
-				stdout := runDockerCommand(0, args...)
-				Expect(stdout).To(ContainSubstring(id))
-				Expect(IsRunningDockerContainer(id)).To(BeFalse())
-			})
-		})
-	})
+	DescribeTable("killing container",
+		func(signal syscall.Signal, expectedExitCode int) {
+			args = []string{"--name", id, "-dt", Image, "sh", "-c"}
+
+			if signal > 0 {
+				args = append(args, fmt.Sprintf("trap \"exit %d\" %d ; while : ; do sleep 1; done", signal, signal))
+			} else {
+				args = append(args, fmt.Sprintf("while : ; do sleep 1; done"))
+			}
+
+			DockerRun(args...)
+
+			if signal > 0 {
+				DockerKill("-s", fmt.Sprintf("%d", signal), id)
+			} else {
+				DockerKill(id)
+			}
+
+			// we have to wait for signal processing (trap)
+			// this is needed even with runc
+			time.Sleep(5 * time.Second)
+
+			exitCode, err := ExitCodeDockerContainer(id)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exitCode).To(Equal(expectedExitCode))
+		},
+		withSignal(syscall.SIGHUP, canBeTrapped),
+		withSignal(syscall.SIGINT, canBeTrapped),
+		withSignal(syscall.SIGQUIT, cannotBeTrapped), //131
+		withSignal(syscall.SIGILL, cannotBeTrapped),  //132
+		withSignal(syscall.SIGTRAP, canBeTrapped),
+		withSignal(syscall.SIGIOT, canBeTrapped),
+		withSignal(syscall.SIGBUS, cannotBeTrapped),  //135
+		withSignal(syscall.SIGFPE, cannotBeTrapped),  //136
+		withSignal(syscall.SIGKILL, cannotBeTrapped), //137
+		withSignal(syscall.SIGUSR1, canBeTrapped),
+		withSignal(syscall.SIGSEGV, cannotBeTrapped), //139
+		withSignal(syscall.SIGUSR2, canBeTrapped),
+		withSignal(syscall.SIGPIPE, cannotBeTrapped), //141
+		withSignal(syscall.SIGALRM, canBeTrapped),
+		withSignal(syscall.SIGTERM, canBeTrapped),
+		withSignal(syscall.SIGSTKFLT, canBeTrapped),
+		withSignal(syscall.SIGCHLD, canBeTrapped),
+		withSignal(syscall.SIGCONT, canBeTrapped),
+		withSignalNotExitCode(syscall.SIGSTOP), //0 - don't change exit code
+		withSignal(syscall.SIGTSTP, canBeTrapped),
+		withSignal(syscall.SIGTTIN, canBeTrapped),
+		withSignal(syscall.SIGTTOU, canBeTrapped),
+		withSignal(syscall.SIGURG, canBeTrapped),
+		withSignal(syscall.SIGXCPU, canBeTrapped),
+		withSignal(syscall.SIGXFSZ, canBeTrapped),
+		withSignal(syscall.SIGVTALRM, canBeTrapped),
+		withSignal(syscall.SIGPROF, canBeTrapped),
+		withSignalNotExitCode(syscall.SIGWINCH), //0 - don't change exit code
+		withSignal(syscall.SIGIO, canBeTrapped),
+		withSignal(syscall.SIGPWR, canBeTrapped),
+		withoutSignal(),
+	)
 })


### PR DESCRIPTION
this patch re-implement docker kill tests in order to check
all possible signals and its exit codes

fixes #222

Signed-off-by: Julio Montes <julio.montes@intel.com>