### PR TITLE
tests: Fix kong test at the docker popular images test

### DIFF
--- a/integration/docker_popular_images/popular_docker_images.bats
+++ b/integration/docker_popular_images/popular_docker_images.bats
@@ -198,7 +198,7 @@ setup () {
 }
 
 @test "check kong configuration file is valid" {
-	$DOCKER_EXE run --rm -i kong bash -c "cp /etc/kong/kong.conf.default /usr/local/kong/kong.conf; kong check /usr/local/kong/kong.conf | grep valid"
+	$DOCKER_EXE run --rm -i kong bash -c "kong check /etc/kong/kong.conf.default | grep valid"
 }
 
 @test "check kernel version in a mageia container" {


### PR DESCRIPTION
Change the configuration file for the kong test of the most popular
images from Docker Hub.

Fixes #444

Signed-off-by: Gabriela Cervantes Tellez <gabriela.cervantes.tellez@intel.com>