### PR TITLE
tests: Add docker network functionality to docker.go

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -220,6 +220,11 @@ func DockerBuild(args ...string) (string, string, int) {
 	return runDockerCommand("build", args...)
 }
 
+// DockerNetwork manages networks
+func DockerNetwork(args ...string) (string, string, int) {
+	return runDockerCommand("network", args...)
+}
+
 // DockerExport will export a container’s filesystem as a tar archive
 func DockerExport(args ...string) (string, string, int) {
 	return runDockerCommand("export", args...)

--- a/integration/docker/network_test.go
+++ b/integration/docker/network_test.go
@@ -15,6 +15,7 @@
 package docker
 
 import (
+	. "github.com/clearcontainers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -26,20 +27,21 @@ var _ = Describe("network", func() {
 	)
 
 	AfterEach(func() {
-		args = []string{"network", "rm", networkName}
-		runDockerCommand(0, args...)
-		args = []string{"network", "ls"}
-		stdout := runDockerCommand(0, args...)
+		_, _, exitCode := DockerNetwork("rm", networkName)
+		Expect(exitCode).To(Equal(0))
+		stdout, _, exitCode := DockerNetwork("ls")
+		Expect(exitCode).To(Equal(0))
 		Expect(stdout).NotTo(ContainSubstring(networkName))
 	})
 
 	Describe("network with docker", func() {
 		Context("create network", func() {
 			It("should display the network's name", func() {
-				args = []string{"network", "create", "-d", "bridge", networkName}
-				runDockerCommand(0, args...)
-				args = []string{"network", "inspect", networkName}
-				runDockerCommand(0, args...)
+				args = []string{"create", "-d", "bridge", networkName}
+				_, _, exitCode := DockerNetwork(args...)
+				Expect(exitCode).To(Equal(0))
+				_, _, exitCode = DockerNetwork("inspect", networkName)
+				Expect(exitCode).To(Equal(0))
 			})
 		})
 	})


### PR DESCRIPTION
Add docker network functionality at docker.go in order to improve
readability and maintenance to integration tests.

Fixes #446

Signed-off-by: Gabriela Cervantes Tellez <gabriela.cervantes.tellez@intel.com>