### PR TITLE
tests: add DockerRun function to restart test

### DIFF
--- a/integration/docker/restart_test.go
+++ b/integration/docker/restart_test.go
@@ -28,8 +28,8 @@ var _ = Describe("restart", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-td", "--name", id, Image, "sh"}
-		runDockerCommand(0, args...)
+		_, _, exitCode := DockerRun("-td", "--name", id, Image, "sh")
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Implement DockerRun function from docker.go at the restart test

Fixes #456

Signed-off-by: Gabriela Cervantes Tellez <gabriela.cervantes.tellez@intel.com>