### PR TITLE
tests: Implement DockerRun function at integration tests

### DIFF
--- a/integration/docker/export_test.go
+++ b/integration/docker/export_test.go
@@ -25,14 +25,13 @@ import (
 
 var _ = Describe("export", func() {
 	var (
-		args []string
-		id   string
+		id string
 	)
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-td", "--name", id, Image}
-		runDockerCommand(0, args...)
+		_, _, exitCode := DockerRun("-td", "--name", id, Image)
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {

--- a/integration/docker/inspect_test.go
+++ b/integration/docker/inspect_test.go
@@ -35,9 +35,8 @@ var _ = Describe("inspect", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-t", "--name", id, Image, "true"}
-		runDockerCommand(0, args...)
-
+		_, _, exitCode := DockerRun("-t", "--name", id, Image, "true")
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {

--- a/integration/docker/load_test.go
+++ b/integration/docker/load_test.go
@@ -32,8 +32,8 @@ var _ = Describe("load", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-td", "--name", id, Image}
-		runDockerCommand(0, args...)
+		_, _, exitCode := DockerRun("-td", "--name", id, Image)
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {

--- a/integration/docker/logs_test.go
+++ b/integration/docker/logs_test.go
@@ -30,8 +30,8 @@ var _ = Describe("logs", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-td", "--name", id, Image, "sh", "-c", "'echo hello'"}
-		runDockerCommand(0, args...)
+		_, _, exitCode := DockerRun("-td", "--name", id, Image, "sh", "-c", "'echo hello'")
+		Expect(exitCode).To(Equal(0))
 		// Issue https://github.com/clearcontainers/runtime/issues/375
 		time.Sleep(2 * time.Second)
 	})

--- a/integration/docker/port_test.go
+++ b/integration/docker/port_test.go
@@ -28,8 +28,8 @@ var _ = Describe("port", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		args = []string{"run", "-td", "-p", "8080:8080", "--name", id, Image}
-		runDockerCommand(0, args...)
+		_, _, exitCode := DockerRun("-td", "-p", "8080:8080", "--name", id, Image)
+		Expect(exitCode).To(Equal(0))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Use DockerRun function at integration tests like port, logs, load, inspect, export

Fixes #458

Signed-off-by: Gabriela Cervantes Tellez <gabriela.cervantes.tellez@intel.com>