### PR TITLE
localCI: fix running as a systemd service

### DIFF
--- a/cmd/localCI/repo.go
+++ b/cmd/localCI/repo.go
@@ -437,6 +437,7 @@ func (r *Repo) testRevision(rev revision, langEnv languageConfig) error {
 		logger:     r.logger,
 		workingDir: langEnv.workingDir,
 		tty:        r.TTY,
+		logDir:     filepath.Join(r.LogDir, rev.logDirName()),
 	}
 
 	// set environment variables


### PR DESCRIPTION
this patch sets log directory in the stage config before
run the stages

fixes #460

Signed-off-by: Julio Montes <julio.montes@intel.com>