### PR TITLE
metrics: Add IO storage metrics to run_all_metrics

### DIFF
--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -49,3 +49,9 @@ bash ${SCRIPT_PATH}/network/network-nginx-ab-benchmark.sh
 #
 # Presume KSM is off, and hence no need to have a settle time
 bash ${SCRIPT_PATH}/density/docker_memory_usage.sh 20 1
+
+# Run I/O storage tests
+bash storage/fio_job.sh -b 16k -o randread -t "storage IO random read bs 16k"
+bash storage/fio_job.sh -b 16k -o randwrite -t "storage IO random write bs 16k"
+bash storage/fio_job.sh -b 16k -o read -t "storage IO linear read bs 16k"
+bash storage/fio_job.sh -b 16k -o write -t "storage IO linear write bs 16k"


### PR DESCRIPTION
These basic cases use a similar configuration (block size, ioengine etc),
but using different operations:

- Linear read
- Linear write
- Random read
- Random write

Fixes: #466

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>