### PR TITLE
localCI: don't re-test a PR if its hash doesn't change

### DIFF
--- a/cmd/localCI/github.go
+++ b/cmd/localCI/github.go
@@ -37,8 +37,8 @@ type Github struct {
 }
 
 const (
-	timeoutShortRequest = 10 * time.Second
-	timeoutLongRequest  = 20 * time.Second
+	timeoutShortRequest = 60 * time.Second
+	timeoutLongRequest  = 120 * time.Second
 )
 
 // newGithub returns an object of type Github

--- a/cmd/localCI/repo.go
+++ b/cmd/localCI/repo.go
@@ -299,8 +299,11 @@ func (r *Repo) loop() {
 			}
 		}
 
-		r.logger.Debugf("testing revisions: %#v", revisionsToTest)
-		r.testRevisions(revisionsToTest, &revisionsTested)
+		// test only if there are at least 1 revision
+		if len(revisionsToTest) > 0 {
+			r.logger.Debugf("testing revisions: %#v", revisionsToTest)
+			r.testRevisions(revisionsToTest, &revisionsTested)
+		}
 
 		r.logger.Debugf("going to sleep: %s", r.RefreshTime)
 		time.Sleep(r.refresh)


### PR DESCRIPTION
this patch increases timeout used to request data from
github server, also if the list of revisions is empty
the list of revisions tested is not updated to avoid
localCI re-tests pull requests already tested

fixes #468

Signed-off-by: Julio Montes <julio.montes@intel.com>