### PR TITLE
metrics: Verify dependencies before execute all

### DIFF
--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -26,6 +26,11 @@ fi
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
+# Check tools/commands dependencies
+echo "Check dependencies"
+cmds=("docker" "bc" "awk" "smem" "ab")
+check_cmds "${cmds[@]}"
+
 echo "Running all metrics tests"
 
 # Run the time tests


### PR DESCRIPTION
The "all" metrics tests execution is interrupted for
errors related to commands/tools dependencies, it is
better to ask them before execution. This might seem
redundant due to these dependencies could be requested
by each metrics test, however this allows to avoid
this kind of interruption/errors running metrics test
as a group or running an independent test.

Fixes: #471

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>