### PR TITLE
metrics: network: allow to specify another runtime

### DIFF
--- a/metrics/network/network-nginx-ab-benchmark.sh
+++ b/metrics/network/network-nginx-ab-benchmark.sh
@@ -57,7 +57,7 @@ function nginx_ab_networking {
 	container_name="docker-nginx"
 	total_requests=$(mktemp)
 
-	$DOCKER_EXE run -d --name ${container_name} -p ${port} ${image} > /dev/null
+	$DOCKER_EXE run -d --name ${container_name} --runtime $RUNTIME -p ${port} ${image} > /dev/null
 	sleep_secs=2
 	echo >&2 "WARNING: sleeping for $sleep_secs seconds (see https://github.com/01org/cc-oci-runtime/issues/828)"
 	sleep "$sleep_secs"


### PR DESCRIPTION
This metrics test should use RUNTIME var in order to be executed
using a different runtime. This commit adds that.

Fixes: #473

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>