### PR TITLE
metrics: network: Fix conflict of container already in use

### DIFF
--- a/metrics/network/network-metrics-cpu-consumption.sh
+++ b/metrics/network/network-metrics-cpu-consumption.sh
@@ -53,6 +53,7 @@ function cpu_consumption {
 	# Arguments to run the client
 	local extra_args="-d"
 
+	init_env
 	setup
 	local server_command="iperf -p ${port} -s"
 	local server_address=$(start_server "$server_name" "$image" "$server_command")


### PR DESCRIPTION
This script fails due to a container is already using
the same name. This happens because it does not clean the environment
before to run the tool/test. This commit adds a common function
in order to clean up the current containers running.

Fixes: #497

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>