### PR TITLE
Add Openshift setup and test

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -37,11 +37,22 @@ containers_config_path="/etc/containers"
 echo "Copy containers policy from CRI-O repo to $containers_config_path"
 sudo mkdir -p "$containers_config_path"
 sudo cp test/policy.json "$containers_config_path"
-
-echo "Setup cc-runtime as the runtime to use"
-sudo sed -i.bak 's/\/usr\/bin\/runc/\/usr\/local\/bin\/cc-runtime/g' /etc/crio/crio.conf
-
 popd
+
+echo "Install runc for CRI-O"
+go get -d github.com/opencontainers/runc
+pushd "${GOPATH}/src/github.com/opencontainers/runc"
+make
+sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
+popd
+
+crio_config_file="/etc/crio/crio.conf"
+echo "Set runc as default runtime in CRI-O for trusted workloads"
+sudo sed -i 's/^runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
+
+echo "Set Clear containers as default runtime in CRI-O for untrusted workloads"
+sudo sed -i 's/default_workload_trust = "trusted"/default_workload_trust = "untrusted"/' "$crio_config_file"
+sudo sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/local\/bin\/cc-runtime"/' "$crio_config_file"
 
 service_path=""
 crio_service_file=""

--- a/integration/openshift/README.md
+++ b/integration/openshift/README.md
@@ -1,0 +1,25 @@
+# OpenShift\* integration with Clear Containers
+
+This section contains scripts to setup an OpenShift enviornment on top
+of Clear Containers. Currently, these scripts only work for **Fedora**.
+
+Execute the steps below on a clean environment.
+
+Setup the environment:
+
+```
+$ ./setup.sh
+```
+
+Initialize the master server and the node server:
+
+```
+$ ./init.sh
+```
+
+Run a basic verification test to check the environment was built correctly
+(recommended). To run the test you need the `bats` framework.
+
+```
+$ bats hello_world.bats
+```

--- a/integration/openshift/data/hello-pod-cc.json
+++ b/integration/openshift/data/hello-pod-cc.json
@@ -1,0 +1,52 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "hello-openshift",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "hello-openshift"
+    },
+	"annotations": {
+      "io.kubernetes.cri-o.TrustedSandbox": "false"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "hello-openshift",
+        "image": "openshift/hello-openshift",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {},
+        "volumeMounts": [
+          {
+            "name":"tmp",
+            "mountPath":"/tmp"
+          }
+        ],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "capabilities": {},
+        "securityContext": {
+          "capabilities": {},
+          "privileged": false
+        }
+      }
+    ],
+    "volumes": [
+      {
+        "name":"tmp",
+        "emptyDir": {}
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}

--- a/integration/openshift/hello_world.bats
+++ b/integration/openshift/hello_world.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# *-*- Mode: sh; sh-basic-offset: 8; indent-tabs-mode: nil -*-*
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "${BATS_TEST_DIRNAME}/openshiftrc"
+load "${BATS_TEST_DIRNAME}/../kubernetes/lib.sh"
+
+setup() {
+	pod_name="hello-openshift"
+	image="openshift/${pod_name}"
+	sudo -E /usr/local/bin/crioctl image pull "$image"
+}
+
+@test "Hello Openshift using CC" {
+	# The below json file was taken from:
+	# https://github.com/openshift/origin/tree/master/examples/hello-openshift
+	# and modified to be an untrusted workload and then use Clear Containers.
+	sudo -E oc create -f "${BATS_TEST_DIRNAME}/data/hello-pod-cc.json"
+	wait_time=20
+	sleep_time=3
+	output_file=$(mktemp)
+	cmd="sudo -E oc describe pod/${pod_name} | grep State | grep Running"
+	# Wait for nginx service to come up
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+	container_id=$(sudo -E oc describe pod/${pod_name} | grep "Container ID" | cut -d '/' -f3)
+	# Verify that the running container is a Clear Container
+	sudo -E cc-runtime list | grep "$container_id" | grep "running"
+	# Verify connectivity
+	container_ip=$(sudo -E oc get pod "${pod_name}" -o yaml | grep "podIP" | awk '{print $2}')
+	container_port=$(sudo -E oc get pod "${pod_name}" -o yaml | grep "Port" | awk '{print $3}')
+	curl "${container_ip}:${container_port}" &> "$output_file"
+	grep "Hello OpenShift" "$output_file"
+}
+
+teardown() {
+	rm "$output_file"
+	sudo -E oc delete pod "$pod_name"
+}

--- a/integration/openshift/init.sh
+++ b/integration/openshift/init.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/openshiftrc"
+
+echo "Disable SELinux"
+echo "There is an issue when runnig CRI-O workloads with SELinux enabled
+For more information, please take a look at:
+https://github.com/kubernetes-incubator/cri-o/issues/528"
+sudo setenforce 0
+
+echo "Create configuration files"
+openshift start --write-config="$openshift_config_path"
+
+cp "$node_config" "$node_crio_config"
+
+cat << EOF >> "$node_crio_config"
+kubeletArguments:
+  node-labels:
+  - region=infra
+  image-service-endpoint:
+  - "/var/run/crio.sock"
+  container-runtime-endpoint:
+  - "/var/run/crio.sock"
+  container-runtime:
+  - "remote"
+  runtime-request-timeout:
+  - "15m"
+  enable-cri:
+  - "true"
+EOF
+
+echo "Start Master"
+sudo -E openshift start master --config "$master_config" &> master.log &
+
+echo "Start Node"
+sudo -E openshift start node --config "$node_crio_config" &> node.log &

--- a/integration/openshift/openshiftrc
+++ b/integration/openshift/openshiftrc
@@ -1,0 +1,7 @@
+# These variables will be used for launching the cluster and
+# for executing the tests.
+openshift_config_path="$(pwd)/openshift.local.config"
+master_config="$openshift_config_path/master/master-config.yaml"
+node_config="$openshift_config_path/node-$(hostname)/node-config.yaml"
+node_crio_config="$openshift_config_path/node-$(hostname)/node-config-crio.yaml"
+export KUBECONFIG="$openshift_config_path/master/admin.kubeconfig"

--- a/integration/openshift/setup.sh
+++ b/integration/openshift/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source /etc/os-release
+source "$SCRIPT_PATH/../../test-versions.txt"
+
+if [ "$ID" != fedora ]; then
+	echo "Currently this script only works for Fedora."
+	exit 1
+fi
+
+sudo -E dnf -y update
+
+echo "Install Dependencies for Openshift"
+sudo -E dnf -y install bind-utils bsdtar container-selinux createrepo \
+		file jq json-glib-devel krb5-devel mercurial libassuan-devel \
+		libselinux-python NetworkManager rsync skopeo-containers tito
+
+echo "Install Clear Containers, including dependencies"
+pushd "${SCRIPT_PATH}/../../.ci"
+./setup.sh
+popd
+
+echo "Set Overlay as storage driver for CRI-O"
+crio_config_file="/etc/crio/crio.conf"
+sudo sed -i 's/storage_driver = ""/storage_driver = "overlay2"/' "$crio_config_file"
+
+echo "Install Skopeo"
+skopeo_repo="github.com/projectatomic/skopeo"
+go get -d "$skopeo_repo" || true
+pushd "$GOPATH/src/$skopeo_repo"
+make binary-local
+sudo -E make install-binary
+popd
+
+echo "Install Openshift"
+openshift_repo="github.com/openshift/origin"
+go get -d "$openshift_repo" || true
+pushd "$GOPATH/src/$openshift_repo"
+git checkout "$origin_version"
+export OS_OUTPUT_GOPATH=1
+make
+sudo cp _output/local/bin/linux/amd64/{openshift,oc,oadm} /usr/bin
+popd

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -11,3 +11,6 @@ kernel_version="4.5-50"
 
 # Go version to use for building and testing Clear Containers
 go_version="1.8.3"
+
+# Openshift Origin version compatible with Clear Containers
+origin_version="release-3.6"


### PR DESCRIPTION
This commit adds scripts to setup the environment for running OpenShift on top of Clear Containers, initialize the nodes and run a simple Connectivity test.

Fixes #465.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>