### PR TITLE
cmd: emailreport: Notify results status

### DIFF
--- a/cmd/emailreport/README.md
+++ b/cmd/emailreport/README.md
@@ -10,7 +10,30 @@ file can be specified by command line or it is installed in
 WARNING: The password for the SMTP authentication will be in TOML
 configuration text plane file.
 
-# Usage
+## Options
+The `emailreport` tool takes a number of options.
+
+### Add comments/suggestions in the message body
+```
+-c    comments/suggestions
+```
+
+### Specify the TOML configuration file by command line
+```
+-f    path to TOML configuration file
+```
+
+### Add/Overwrite email subject
+```
+-s    email subject
+```
+
+### Help
+```
+-h    show help
+```
+
+## Usage
 ```bash
-$ ./emailreport [-f <conf.toml>]
+$ ./emailreport [-f <conf.toml>] [-c <"comments">] [-s <"subject">]
 ```

--- a/cmd/emailreport/mail.go
+++ b/cmd/emailreport/mail.go
@@ -23,7 +23,7 @@ import (
 // HeaderRFC822 provides a header as a
 // string according the RFC822 Standard for ARPA
 // Internet Text Messages.
-func HeaderRFC822(conf Configuration) string {
+func HeaderRFC822(conf Configuration, status string) string {
 	var header string
 
 	if conf.Mail.From == "" {
@@ -45,7 +45,7 @@ func HeaderRFC822(conf Configuration) string {
 		header += "cc: " + strings.Join(conf.Mail.Cc, ",") + "\n"
 	}
 
-	header += "Subject: " + conf.Mail.Subject + "\n\n"
+	header += "Subject: " + conf.Mail.Subject + " status: " + status + "\n\n"
 
 	return header
 }
@@ -53,13 +53,13 @@ func HeaderRFC822(conf Configuration) string {
 // SendByEmail allows to send the result output of
 // checkmetrics execution to a whitelist of emails.
 // This list is described by a TOML configuration file.
-func SendByEmail(conf Configuration, body string) {
+func SendByEmail(conf Configuration, body string, status string) {
 	var header string
 	var msg string
 	var auth smtp.Auth
 	var server string
 
-	header = HeaderRFC822(conf)
+	header = HeaderRFC822(conf, status)
 	msg = header + body
 
 	auth = smtp.PlainAuth(

--- a/cmd/emailreport/main.go
+++ b/cmd/emailreport/main.go
@@ -74,6 +74,7 @@ func main() {
 	var cmd string
 	var basefile string
 	var metricsdir string
+	var status string = "PASS"
 
 	flag.StringVar(&confFile, "f", "", "Configuration file")
 	flag.StringVar(&comments, "c", "", "comments/suggestions")
@@ -120,17 +121,16 @@ func main() {
 	// checkmetrics execution
 	out, err := exec.Command(cmd, "--basefile", basefile, "--metricsdir", metricsdir).Output()
 	if err != nil {
-		body = fmt.Sprintf(body + "%s\n\n %v", out, err)
-		SendByEmail(conf, body)
-		log.Fatal("checkmetrics execution: ", err)
-	}
-
-	if len(out) == 0 {
-		body = fmt.Sprintf(body + "no output from " + cmd)
-		SendByEmail(conf, body)
-		log.Fatal("no output from: " + cmd)
+		status = "FAIL"
+		if len(out) == 0 {
+			body = fmt.Sprintf(body + "no output from " + cmd)
+		} else {
+			body = fmt.Sprintf(body + "%s\n\n %v", out, err)
+		}
+		SendByEmail(conf, body, status)
+		log.Fatal(cmd + " error: ", err)
 	}
 
 	body = fmt.Sprintf(body + "%s", out)
-	SendByEmail(conf, body)
+	SendByEmail(conf, body, status)
 }

--- a/cmd/emailreport/main.go
+++ b/cmd/emailreport/main.go
@@ -74,10 +74,12 @@ func main() {
 	var cmd string
 	var basefile string
 	var metricsdir string
+	var subject string
 	var status string = "PASS"
 
 	flag.StringVar(&confFile, "f", "", "Configuration file")
 	flag.StringVar(&comments, "c", "", "comments/suggestions")
+	flag.StringVar(&subject, "s", "", "email subject")
 	flag.Parse()
 
 	// If there is not any input file specified by command line
@@ -106,6 +108,11 @@ func main() {
 	// Parsing TOML configuration file
 	if _, err := toml.DecodeFile(confFile, &conf); err != nil {
 		log.Fatal(err)
+	}
+
+	// The subject can be overwritten by command line
+	if subject != "" {
+		conf.Mail.Subject = subject
 	}
 
 	// Add comments to the body message


### PR DESCRIPTION
These commits allow to notify the results of checmetrics execution by email even if  it fails, furthermore a commit adds the "comments" option in order to show more information about an event.