### PR TITLE
kubernetes: pull images before launching workload

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -29,7 +29,7 @@ sudo -E kubectl create --namespace kube-system -f "${SCRIPT_PATH}/data/kube-flan
 # The kube-dns pod usually takes around 30 seconds to get ready
 # This instruction will wait until it is up and running, so we can
 # start creating our containers.
-dns_wait_time=60
+dns_wait_time=180
 sleep_time=5
 cmd="sudo -E kubectl get pods --all-namespaces | grep dns | grep Running"
 waitForProcess "$dns_wait_time" "$sleep_time" "$cmd"

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -18,25 +18,29 @@
 load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
+	nginx_image="nginx"
+	busybox_image="busybox"
+	service_name="${nginx_image}-service"
 	export KUBECONFIG=/etc/kubernetes/admin.conf
 	master=$(hostname)
 	sudo -E kubectl taint nodes "$master" node-role.kubernetes.io/master:NoSchedule-
+	sudo -E crioctl image pull "$busybox_image"
+	sudo -E crioctl image pull "$nginx_image"
 }
 
 @test "Verify nginx connectivity between pods" {
-	service_name="nginx"
 	wait_time=20
 	sleep_time=3
 	output_file=$(mktemp)
 	echo $output_file
 	cmd="sudo -E kubectl get pods | grep $service_name | grep Running"
-	sudo -E kubectl run "$service_name" --image="$service_name" --replicas=2
+	sudo -E kubectl run "$service_name" --image="$nginx_image" --replicas=2
 	sudo -E kubectl expose deployment "$service_name" --port=80
 	sudo -E kubectl get svc,pod
 	# Wait for nginx service to come up
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
-	run bash -c "sudo -E kubectl run busybox --rm -ti --restart=Never \
-		--image=busybox -- wget --timeout=1 $service_name > $output_file"
+	run bash -c "sudo -E kubectl run test-nginx --rm -ti --restart=Never \
+		--image=$busybox_image -- wget --timeout=1 $service_name > $output_file"
 	[ "$status" -eq 0 ]
 	grep "index.html" "$output_file"
 }


### PR DESCRIPTION
The nginx test has a timeout for launching the workload, as
the required images are downloaded at that time, sometimes the
test fails because of the timeout. To prevent the failure, this fix pulls the
image before launching the workload.

Also when initializing the kubernetes services, including the
dns pod, sometimes it is not enough 60 seconds to pull all images
and start the services, then, this also increases the timeout of
the initialization to 180 secs.

Fixes #511.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>