### PR TITLE
CI: Install packages from clearlinux.org instead of OBS

### DIFF
--- a/.ci/install_qemu_lite.sh
+++ b/.ci/install_qemu_lite.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <CLEAR_RELEASE> <QEMU_LITE_VERSION>"
+    echo "       Install the QEMU_LITE_VERSION from clear CLEAR_RELEASE."
+    exit 1
+fi
+
+clear_release="$1"
+qemu_lite_version="$2"
+qemu_lite_bin="qemu-lite-bin-${qemu_lite_version}.x86_64.rpm"
+qemu_lite_data="qemu-lite-data-${qemu_lite_version}.x86_64.rpm"
+
+echo -e "Install qemu-lite ${qemu_lite_version}"
+
+# download packages
+curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/${qemu_lite_bin}"
+curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/${qemu_lite_data}"
+
+# install packages using alien
+sudo alien -i "./${qemu_lite_bin}"
+sudo alien -i "./${qemu_lite_data}"
+
+# cleanup
+rm -f "./${qemu_lite_bin}"
+rm -f "./${qemu_lite_data}"

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,13 +1,20 @@
 # Well known working crio tag/commit/branch
 crio_version=959aab4fd5dbc315ca2dc84a90599c2108756a2c
 
+# Clear Containers image version
+image_version=17270
+
 # Kernel Version to use on recent Linux Distros
-kernel_clear_release=16680
-kernel_version="4.9.35-76"
+kernel_clear_release=17580
+kernel_version="4.9.47-77"
 
 # Kernel Version to use for Ubuntu 14.04 (Semaphore Env)
-kernel_clear_release=12760
-kernel_version="4.5-50"
+semaphore_kernel_clear_release=12760
+semaphore_kernel_version="4.5-50"
+
+# Qemu-lite Version
+qemu_clear_release=17580
+qemu_lite_sha=741f430a960b5b67745670e8270db91aeb083c5f-29
 
 # Go version to use for building and testing Clear Containers
 go_version="1.8.3"


### PR DESCRIPTION
This change install clear-containers-image, linux-container and
qemu-lite packages from download.clearlinux.org using `alien` as
the packages in the site are RPM.

This change is to not rely on OBS platform as sometimes the service
is down.

Fixes #513.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>