### PR TITLE
ci: allow to install kernel image in ubuntu 16.10

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -108,7 +108,7 @@ if [ "$VERSION_ID" == "14.04" ]; then
 	popd
 	rm -rf ${ostree_dir}
 
-elif [ "$VERSION_ID" == "16.04" ] || [ "$VERSION_ID" == "17.04" ]; then
+elif [ "$VERSION_ID" == "16.04" ] || [ "$VERSION_ID" == "17.04" ] || [ "$VERSION_ID" == "16.10" ]; then
 	echo "Install Build Tools"
 	sudo -E apt install -y build-essential python pkg-config zlib1g-dev
 


### PR DESCRIPTION
This commit adds "16.10" as a valid verison ID in order
to install the Clear Containers kernel image.

Fixes: #519

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>