### PR TITLE
metrics: network: Fix dirty environment

### DIFF
--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -122,6 +122,8 @@ function iperf3_bidirectional_bandwidth_client_server {
 
 echo "Currently this script is using ramfs for tmp (see https://github.com/01org/cc-oci-runtime/issues/152)"
 
+init_env
+
 iperf3_bandwidth
 
 iperf3_jitter


### PR DESCRIPTION
This script fails due to a container is already using
the same name. This happens because it does not clean
the environment before to run the tool/test. This commit
uses a common function in order to clean up the current
containers running.

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>