### PR TITLE
CI: Update kubernetes to 1.7.8 and execute test without a tty

### DIFF
--- a/.ci/data/crio.service
+++ b/.ci/data/crio.service
@@ -3,7 +3,7 @@ Description=CRI-O daemon
 Documentation=https://github.com/kubernetes-incubator/cri-o
 
 [Service]
-ExecStart=/usr/local/bin/crio --debug
+ExecStart=/usr/local/bin/crio --log-level debug
 Restart=on-failure
 RestartSec=5
 

--- a/integration/kubernetes/setup.sh
+++ b/integration/kubernetes/setup.sh
@@ -17,6 +17,7 @@
 set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../test-versions.txt"
 
 echo "Install Kubernetes"
 sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
@@ -24,7 +25,7 @@ deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo -E apt update
-sudo -E apt install -y docker.io kubelet=1.6.7-00 kubeadm=1.6.7-00 kubectl=1.6.7-00
+sudo -E apt install -y docker.io kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 sudo -E apt-mark hold kubelet kubeadm kubectl
 
 echo "Install Clear Containers, including dependencies"

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,5 +1,5 @@
 # Well known working crio tag/commit/branch
-crio_version=400713a58bedb88678e84b72d4620847c8d27fec
+crio_version=v1.0.0
 
 # Runc version compatible with crio_version
 runc_version=84a082bfef6f932de921437815355186db37aeb1

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -22,6 +22,9 @@ qemu_lite_sha=741f430a960b5b67745670e8270db91aeb083c5f-29
 # Go version to use for building and testing Clear Containers
 go_version="1.8.3"
 
+#Kubernetes version compatible with Clear Containers
+kubernetes_version="1.7.8-00"
+
 # Openshift Origin version compatible with Clear Containers
 origin_version="v3.6.0"
 origin_commit="c4dd4cf"


### PR DESCRIPTION
Updates kubernetes version used in the tests from 1.6.7 to
1.7.8. 

Jenkins job is not able to open a tty when running this test.
As this test is not required to use a tty, removing -t option
from the kubectl command.

Fixes #563.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>