### PR TITLE
CI: update sha version of CRI-O to fix integration tests

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -21,10 +21,21 @@ cidir=$(dirname "$0")
 source "${cidir}/../test-versions.txt"
 
 echo "Get CRI-O sources"
-go get -d github.com/kubernetes-incubator/cri-o || true
-pushd $GOPATH/src/github.com/kubernetes-incubator/cri-o
+crio_repo="github.com/kubernetes-incubator/cri-o"
+go get -d "$crio_repo" || true
+pushd "${GOPATH}/src/${crio_repo}"
 git fetch
 git checkout "${crio_version}"
+
+echo "Get CRI Tools"
+critools_repo="github.com/kubernetes-incubator/cri-tools"
+go get "$critools_repo" || true
+pushd "${GOPATH}/src/${critools_repo}"
+crictl_commit=$(grep "ENV CRICTL_COMMIT" "${GOPATH}/src/${crio_repo}/Dockerfile" | cut -d " " -f3)
+git checkout "${crictl_commit}"
+go install ./cmd/crictl
+sudo install "${GOPATH}/bin/crictl" /usr/bin
+popd
 
 echo "Installing CRI-O"
 sudo -E PATH=$PATH sh -c "make clean"

--- a/integration/cri-o/crio.bats
+++ b/integration/cri-o/crio.bats
@@ -43,6 +43,7 @@ function teardown() {
 	run crioctl ctr start --id "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	sleep 5
 	run crioctl ctr status --id "$ctr_id"
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,5 +1,5 @@
 # Well known working crio tag/commit/branch
-crio_version=959aab4fd5dbc315ca2dc84a90599c2108756a2c
+crio_version=400713a58bedb88678e84b72d4620847c8d27fec
 
 # Clear Containers image version
 image_version=17270


### PR DESCRIPTION
Today we hit an issue of how CRI-O handle container images.
https://github.com/kubernetes-incubator/cri-o/issues/902

A fix from CRI-O has been released and we need to update to
that version.
Since we rely on their test/helpers.bash script to run our
tests, and as that script now uses crictl (from cri-tools repo),
this change also installs crictl binary.

Fixes #530.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>