### PR TITLE
metrics: run only a group of tests

### DIFF
--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -31,32 +31,104 @@ echo "Check dependencies"
 cmds=("docker" "bc" "awk" "smem" "ab")
 check_cmds "${cmds[@]}"
 
-echo "Running all metrics tests"
+function help() {
+echo "$(cat << EOF
+Usage: $0 [-h] [--help] [-v] [--version]
+   Description:
+        This script allows to execute the metrics tests
+        in different groups which are focused in different
+        aspects of the containers. If no option is specified
+        all tests will be executed.
+   Options:
+        -h, --help         Shows help
+        -l, --latency      Run latency/time metrics tests
+        -m, --memory       Run memory metrics tests
+        -n, --network      Run network metrics tests
+        -s, --storage      Run I/O storage metrics tests
+EOF
+)"
+}
 
-# Run the time tests
-bash ${SCRIPT_PATH}/time/docker_workload_time.sh true busybox $RUNTIME 100
+# Only run latency metrics tests
+function run_latency_tests() {
+	# Run the time tests
+	bash ${SCRIPT_PATH}/time/docker_workload_time.sh true busybox $RUNTIME 100
+}
 
-# Run the network metrics
-bash ${SCRIPT_PATH}/network/network-latency.sh
-bash ${SCRIPT_PATH}/network/network-metrics-cpu-consumption.sh
-bash ${SCRIPT_PATH}/network/network-metrics-iperf3.sh
-bash ${SCRIPT_PATH}/network/network-metrics-memory-pss-1g.sh
-bash ${SCRIPT_PATH}/network/network-metrics-memory-pss.sh
-bash ${SCRIPT_PATH}/network/network-metrics-memory-rss-1g.sh
-bash ${SCRIPT_PATH}/network/network-metrics-nuttcp.sh
-bash ${SCRIPT_PATH}/network/network-metrics.sh
-bash ${SCRIPT_PATH}/network/network-nginx-ab-benchmark.sh
+# Only run network metrics tests
+function run_network_tests() {
+	# Run the network metrics
+	bash ${SCRIPT_PATH}/network/network-latency.sh
+	bash ${SCRIPT_PATH}/network/network-metrics-cpu-consumption.sh
+	bash ${SCRIPT_PATH}/network/network-metrics-iperf3.sh
+	bash ${SCRIPT_PATH}/network/network-metrics-memory-pss-1g.sh
+	bash ${SCRIPT_PATH}/network/network-metrics-memory-pss.sh
+	bash ${SCRIPT_PATH}/network/network-metrics-memory-rss-1g.sh
+	bash ${SCRIPT_PATH}/network/network-metrics-nuttcp.sh
+	bash ${SCRIPT_PATH}/network/network-metrics.sh
+	bash ${SCRIPT_PATH}/network/network-nginx-ab-benchmark.sh
+}
 
-# Run the density/footprint scripts
-# If you have KSM enabled, the 'settle time' depends on the default settings.
-# For instance, for an Ubuntu 16.04 default install, it takes about 200s for
-# 20 CC containers footprint to 'settle down'.
-#
-# Presume KSM is off, and hence no need to have a settle time
-bash ${SCRIPT_PATH}/density/docker_memory_usage.sh 20 1
+# Only run memory/density metrics tests
+function run_memory_tests() {
+	# Run the density/footprint scripts
+	# If you have KSM enabled, the 'settle time' depends on the default settings.
+	# For instance, for an Ubuntu 16.04 default install, it takes about 200s for
+	# 20 CC containers footprint to 'settle down'.
+	#
+	# Presume KSM is off, and hence no need to have a settle time
+	bash ${SCRIPT_PATH}/density/docker_memory_usage.sh 20 1
+}
 
-# Run I/O storage tests
-bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o randread -t "storage IO random read bs 16k"
-bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o randwrite -t "storage IO random write bs 16k"
-bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o read -t "storage IO linear read bs 16k"
-bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o write -t "storage IO linear write bs 16k"
+# Only run I/O storage metrics tests
+function run_storage_tests() {
+	# Run I/O storage tests
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o randread -t "storage IO random read bs 16k"
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o randwrite -t "storage IO random write bs 16k"
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o read -t "storage IO linear read bs 16k"
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o write -t "storage IO linear write bs 16k"
+}
+
+# Run all metrics tests
+function run_all_tests() {
+	run_latency_tests
+	run_network_tests
+	run_memory_tests
+	run_storage_tests
+}
+
+# This script will run all metricts tests by default if no
+# option is specified.
+function main() {
+	if [ $# -eq 0 ]; then
+		echo "Running all metrics tests"
+		run_all_tests
+		exit 0
+	fi
+
+	while (( $# )); do
+		case $1 in
+		-h|--help)
+			help
+			exit 0;
+		;;
+		-l|--latency)
+			run_latency_tests
+		;;
+		-m|--memory)
+			run_memory_tests
+		;;
+		-n|--network)
+			run_network_tests
+		;;
+		-s|--storage)
+			run_storage_tests
+		;;
+		esac
+		shift
+	done
+
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
This commits allows to run just a certain group of tests, however
if no option is specified, it will run all metrics tests by default.

Fixes: #532

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>