### PR TITLE
kill: Sleep before sending a signal

### DIFF
--- a/integration/docker/kill_test.go
+++ b/integration/docker/kill_test.go
@@ -76,6 +76,10 @@ var _ = Describe("docker kill", func() {
 
 			DockerRun(args...)
 
+			// we have to wait for the container workload
+			// to process the trap.
+			time.Sleep(5 * time.Second)
+			
 			if signal > 0 {
 				DockerKill("-s", fmt.Sprintf("%d", signal), id)
 			} else {


### PR DESCRIPTION
We have to let the container start and process the trap before
sending it the expected signal.

Fixes #534

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>