### PR TITLE
CI: Fix typo stopping new runtime config being used

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -43,7 +43,7 @@ export LOCALSTATEDIR=/var
 
 runtime_config_path="${SYSCONFDIR}/clear-containers/configuration.toml"
 
-PKGDEFAULTSDIR="${SHARE_DIR}/defaults/clear-containers"
+PKGDEFAULTSDIR="${SHAREDIR}/defaults/clear-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then


### PR DESCRIPTION
PR #543 attempted to make the tests use the new runtime config file, but
the fix was incorrect due to a silly typo.

Really fixes #542.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>