### PR TITLE
CI: Really really use new runtime config file

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -46,7 +46,7 @@ runtime_config_path="${SYSCONFDIR}/clear-containers/configuration.toml"
 PKGDEFAULTSDIR="${SHAREDIR}/defaults/clear-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 
-if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
+if sudo [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file
 	sudo rm -f "${runtime_config_path}"
 


### PR DESCRIPTION
It appears that in a jenkins environment the new runtime configuration
file is unreadable by a non-root user so elevate privileges when
checking for its existence.

Fixes #547.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>