### PR TITLE
ci: install_proxy: disable proxy ksm mode if on metrics CI

### DIFF
--- a/.ci/data/cc-proxy.conf.noksm
+++ b/.ci/data/cc-proxy.conf.noksm
@@ -1,0 +1,10 @@
+description "Clear Containers Proxy"
+
+# start in normal runlevels when disks are mounted and networking is available
+start on runlevel [2345]
+
+# stop on shutdown/halt, single-user mode and reboot
+stop on runlevel [016]
+
+# Do not enable auto KSM - unwanted under the metrics CI system
+exec /usr/libexec/clear-containers/cc-proxy -log debug -ksm initial


### PR DESCRIPTION
When running under the metrics CI system we do not want the proxy
auto-modifying the KSM modes - we control those from the CI to ensure
we know exactly what we are testing and to get steady state results.

Modify the .ci proxy install script so that it adds the correct
argument to the sytemd file, or copies the correct (added in this
PR) upstart file into place.

Fixes: #559

Signed-off-by: Graham Whaley <graham.whaley@intel.com>