### PR TITLE
ci: metrics: run 'make install' with raised privs

### DIFF
--- a/.ci/run_metrics_ci.sh
+++ b/.ci/run_metrics_ci.sh
@@ -28,7 +28,7 @@ for cmd in "${REPORT_CMDS[@]}"; do
 	if ! command -v "$cmd" > /dev/null 2>&1; then
 		pushd "$CURRENTDIR/../cmd/$cmd"
 		make
-		make install
+		sudo make install
 		popd
 	fi
 done


### PR DESCRIPTION
The metrics ci script should not have to be run as root, as it uses
sudo to raise privs when necessary - but, it invokes a 'make install'
if there are missing commands, and that needs privs to install into
the default system dir paths. Add the relevant `sudo`.

Fixes: #569

Signed-off-by: Graham Whaley <graham.whaley@intel.com>