### PR TITLE
ci: Enable Fedora in our Jenkins CI

### DIFF
--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -51,27 +51,6 @@ sudo -E dnf -y install btrfs-progs-devel device-mapper-devel \
 	libassuan-devel libgpg-error-devel libseccomp-devel      \
 	libselinux-devel ostree-devel pkgconfig
 
-echo "Install qemu Q35 binary"
-sudo -E dnf -y install libcap-ng-devel pixman-devel libcap-devel libattr-devel python zlib-devel
-git clone --branch qemu-lite-v2.9.0 https://github.com/clearcontainers/qemu.git --depth 1
-qemu_dir="qemu"
-pushd ${qemu_dir}
-git checkout qemu-lite-v2.9.0
-./configure --disable-tools --disable-libssh2 --disable-tcmalloc --disable-glusterfs    \
-	--disable-seccomp --disable-{bzip2,snappy,lzo} --disable-usb-redir --disable-libusb \
-	--disable-libnfs --disable-tcg-interpreter --disable-debug-tcg --disable-libiscsi   \
-	--disable-rbd --disable-spice --disable-attr --disable-cap-ng --disable-linux-aio   \
-	--disable-brlapi --disable-vnc-{jpeg,png,sasl} --disable-rdma --disable-bluez       \
-	--disable-fdt --disable-curl --disable-curses --disable-sdl --disable-gtk           \
-	--disable-tpm --disable-vte --disable-vnc --disable-xen --disable-opengl            \
-	--disable-slirp --enable-trace-backend=nop --enable-virtfs --enable-attr            \
-	--enable-cap-ng --target-list=x86_64-softmmu
-make -j$(nproc)
-sudo -E PATH=$PATH sh -c "make install"
-sudo -E mv "$(which qemu-system-x86_64)" /usr/bin/qemu-q35-system-x86_64
-popd
-rm -rf ${qemu_dir}
-
 echo "Install bison binary"
 sudo -E dnf -y install bison
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ crio:
 	bash .ci/install_bats.sh
 	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
 	cd ${CRIO_REPO_PATH} && \
-	RUNTIME=${CC_RUNTIME} STORAGE_OPTS="--storage-driver=aufs" ./test/test_runner.sh crio.bats
+	RUNTIME=${CC_RUNTIME} ./test/test_runner.sh crio.bats
 
 ginkgo:
 	ln -sf . vendor/src


### PR DESCRIPTION
This PR fixes a few things so that we can have Fedora support enabled in our Jenkins CI.

Fixes #576 