### PR TITLE
openshift: Download binaries instead of building them

### DIFF
--- a/integration/openshift/setup.sh
+++ b/integration/openshift/setup.sh
@@ -49,13 +49,15 @@ make binary-local
 sudo -E make install-binary
 popd
 
-echo "Install Openshift"
+echo "Install Openshift Origin"
 openshift_repo="github.com/openshift/origin"
-go get -d "$openshift_repo" || true
-pushd "$GOPATH/src/$openshift_repo"
-git checkout "$origin_version"
-export OS_OUTPUT_GOPATH=1
-make
-sudo cp _output/local/bin/linux/amd64/{openshift,oc,oadm} /usr/bin
-popd
+openshift_tarball="openshift-origin-server-${origin_version}-${origin_commit}-linux-64bit.tar.gz"
+openshift_dir="${openshift_tarball/.tar.gz/}"
+openshift_url="https://${openshift_repo}/releases/download/${origin_version}/${openshift_tarball}"
+
+curl -L -O "$openshift_url"
+tar -xf "$openshift_tarball"
+sudo install ${openshift_dir}/{openshift,oc,oadm} /usr/bin
+rm -rf "$openshift_dir" "${openshift_tarball}"
+
 echo "Openshift + CC Setup finished successfully"

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -20,4 +20,5 @@ qemu_lite_sha=741f430a960b5b67745670e8270db91aeb083c5f-29
 go_version="1.8.3"
 
 # Openshift Origin version compatible with Clear Containers
-origin_version="release-3.6"
+origin_version="v3.6.0"
+origin_commit="c4dd4cf"


### PR DESCRIPTION
This change reduces the time for testing the OpenShift integration.
Instead of clonning the repository and build everything with sources,
we download the binaries they provide in their releases.

Fixes #587.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>