### PR TITLE
ci: integrate OpenShift setup and test execution into the CI process 

### DIFF
--- a/.ci/openshift_setup.sh
+++ b/.ci/openshift_setup.sh
@@ -18,7 +18,7 @@ set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source /etc/os-release
-source "$SCRIPT_PATH/../../test-versions.txt"
+source "$SCRIPT_PATH/../test-versions.txt"
 
 if [ "$ID" != fedora ]; then
 	echo "Currently this script only works for Fedora."
@@ -31,11 +31,6 @@ echo "Install Dependencies for Openshift"
 sudo -E dnf -y install bind-utils bsdtar container-selinux createrepo \
 		file jq json-glib-devel krb5-devel mercurial libassuan-devel \
 		libselinux-python NetworkManager rsync skopeo-containers tito
-
-echo "Install Clear Containers, including dependencies"
-pushd "${SCRIPT_PATH}/../../.ci"
-./setup.sh
-popd
 
 echo "Set Overlay as storage driver for CRI-O"
 crio_config_file="/etc/crio/crio.conf"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -16,4 +16,8 @@
 
 set -e
 
-sudo -E PATH=$PATH bash -c "make check"
+if [ "$OPENSHIFT_CI" = true ]; then
+	sudo -E PATH="$PATH" bash -c "make openshift"
+else
+	sudo -E PATH="$PATH" bash -c "make check"
+fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -53,6 +53,12 @@ bash -f ${cidir}/install_cni_plugins.sh
 echo "Install CRI-O"
 bash -f ${cidir}/install_crio.sh
 
+# If OPENSHIFT_CI envar is defined to true,
+# this setup will install the OpenShift dependencies
+if [ "$OPENSHIFT_CI" = true ]; then
+	bash -f "${cidir}/openshift_setup.sh"
+fi
+
 echo "Drop caches"
 sync
 sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ metrics:
 integration: ginkgo
 	./ginkgo ./integration/docker/ -- -timeout ${TIMEOUT}
 
+openshift:
+	bash .ci/install_bats.sh
+	cd integration/openshift && \
+	./init.sh && \
+	bats hello_world.bats
+
 swarm:
 	bats integration/swarm/swarm.bats
 

--- a/integration/openshift/hello_world.bats
+++ b/integration/openshift/hello_world.bats
@@ -19,6 +19,12 @@ load "${BATS_TEST_DIRNAME}/openshiftrc"
 load "${BATS_TEST_DIRNAME}/../kubernetes/lib.sh"
 
 setup() {
+	# Verify there is a node ready to run containers,
+	# if not, sleep 5s and check again until maximum of 30s
+	cmd="sudo -E oc get nodes | grep \" Ready\""
+	wait_time=30
+	sleep_time=5
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 	pod_name="hello-openshift"
 	image="openshift/${pod_name}"
 	sudo -E /usr/local/bin/crioctl image pull "$image"


### PR DESCRIPTION
This change will allow to setup Openshift environment and execute tests 
through the CI if envar OPENSHIFT_CI=true. The purpose of this change is
to make minimal changes in our jenkins setup.