### PR TITLE
CI: Run openshift along with the other tests

### DIFF
--- a/.ci/openshift_setup.sh
+++ b/.ci/openshift_setup.sh
@@ -21,8 +21,8 @@ source /etc/os-release
 source "$SCRIPT_PATH/../test-versions.txt"
 
 if [ "$ID" != fedora ]; then
-	echo "Currently this script only works for Fedora."
-	exit 1
+	echo "Currently this script only works for Fedora. Skipped Openshift Setup"
+	exit
 fi
 
 sudo -E dnf -y update

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -15,9 +15,12 @@
 # limitations under the License.
 
 set -e
+source /etc/os-release
 
-if [ "$OPENSHIFT_CI" = true ]; then
+sudo -E PATH="$PATH" bash -c "make check"
+
+# Currently, Openshift tests only work on Fedora.
+# We should delete this condition, when it works for Ubuntu.
+if [ "$ID" == fedora  ]; then
 	sudo -E PATH="$PATH" bash -c "make openshift"
-else
-	sudo -E PATH="$PATH" bash -c "make check"
 fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -53,11 +53,7 @@ bash -f ${cidir}/install_cni_plugins.sh
 echo "Install CRI-O"
 bash -f ${cidir}/install_crio.sh
 
-# If OPENSHIFT_CI envar is defined to true,
-# this setup will install the OpenShift dependencies
-if [ "$OPENSHIFT_CI" = true ]; then
-	bash -f "${cidir}/openshift_setup.sh"
-fi
+bash -f "${cidir}/openshift_setup.sh"
 
 echo "Drop caches"
 sync


### PR DESCRIPTION
Instead of having a separate job for testing OpenShift, lets
run them after the integration and CRI-O tests.

Fixes #598.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>