### PR TITLE
CI: Enable full debug in runtime config file

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -57,6 +57,9 @@ fi
 echo "Enabling global logging for runtime in file ${runtime_config_path}"
 sudo sed -i -e 's/^#\(\[runtime\]\|global_log_path =\)/\1/g' "${runtime_config_path}"
 
+echo "Enabling all debug options in file ${runtime_config_path}"
+sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
+
 echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to Semaphore CI updates."
 docker_options="-D --add-runtime cc-runtime=/usr/local/bin/cc-runtime --default-runtime=cc-runtime"
 if [[ ! $(ps -p 1 | grep systemd) ]]; then

--- a/container.go
+++ b/container.go
@@ -38,9 +38,6 @@ type Container struct {
 	// if nil then try to run the container without --pid-file option
 	PidFile *string
 
-	// Debug enables debug output
-	Debug bool
-
 	// LogFile where debug information is written
 	// if nil then try to run the container without --log option
 	LogFile *string
@@ -79,7 +76,6 @@ func NewContainer(workload []string, detach bool) (*Container, error) {
 		Bundle:  b,
 		Console: &console,
 		PidFile: &pidFile,
-		Debug:   true,
 		LogFile: &logFile,
 		Detach:  detach,
 		ID:      &id,
@@ -90,10 +86,6 @@ func NewContainer(workload []string, detach bool) (*Container, error) {
 // calls to run command returning its stdout, stderr and exit code
 func (c *Container) Run() (string, string, int) {
 	args := []string{}
-
-	if c.Debug {
-		args = append(args, "--debug")
-	}
 
 	if c.LogFile != nil {
 		args = append(args, "--log", *c.LogFile)
@@ -173,10 +165,6 @@ func (c *Container) Kill(all bool, signal interface{}) (string, string, int) {
 // calls into exec command returning its stdout, stderr and exit code
 func (c *Container) Exec(process Process) (string, string, int) {
 	args := []string{}
-
-	if c.Debug {
-		args = append(args, "--debug")
-	}
 
 	if c.LogFile != nil {
 		args = append(args, "--log", *c.LogFile)


### PR DESCRIPTION
The runtime is about to lose its old `--debug` command-line option [*]
which is being replaced by a config file option.

Remove occurences of `--debug` and enable debug for *all* components
specified in the runtime config file.

Fixes #600.

[*] - https://github.com/clearcontainers/runtime/pull/693

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>