### PR TITLE
CI: Show shim log at end of CI run

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -31,6 +31,8 @@ if [[ ! $(ps -p 1 | grep systemd) ]]; then
 else
 	echo "Clear Containers Proxy Log:"
 	sudo journalctl --no-pager -u cc-proxy
+	echo "Clear Containers Shim Log:"
+	sudo journalctl --no-pager -t cc-shim
 	echo "CRI-O Log:"
 	sudo journalctl --no-pager -u crio
 fi


### PR DESCRIPTION
Display the shim log messages at the end of the CI Run.

Fixes #605.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>