### PR TITLE
.ci: Copy logs instead of displaying them

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -17,22 +17,53 @@
 # This script will get any execution log that may be useful for
 # debugging any issue related to Clear Containers.
 
-runtime_log_file="/var/lib/clear-containers/runtime/runtime.log"
+log_copy_dest="$1"
 
-echo "Clear Containers Runtime Log:"
-sudo cat "$runtime_log_file"
+runtime_log_location="/var/lib/clear-containers/runtime/runtime.log"
+runtime_log_filename="cc-runtime.log"
+runtime_log_path="${log_copy_dest}/${runtime_log_filename}"
 
-if [[ ! $(ps -p 1 | grep systemd) ]]; then
-	upstart_logs_path="/var/log/upstart"
-	echo "Clear Containers Proxy Log:"
-	sudo cat "${upstart_logs_path}/cc-proxy.log"
-	echo "CRI-O Log:"
-	sudo cat "${upstart_logs_path}/crio.log"
+proxy_log_filename="cc-proxy.log"
+proxy_log_path="${log_copy_dest}/${proxy_log_filename}"
+
+shim_log_filename="cc-shim.log"
+shim_log_path="${log_copy_dest}/${shim_log_filename}"
+
+crio_log_filename="crio.log"
+crio_log_path="${log_copy_dest}/${crio_log_filename}"
+
+upstart_logs_path="/var/log/upstart"
+upstart_proxy_path="${upstart_logs_path}/${proxy_log_filename}"
+upstart_crio_path="${upstart_logs_path}/${crio_log_filename}"
+
+# Copy log files if a destination path is provided, otherwise simply
+# display them.
+if [ ${log_copy_dest} ]; then
+	sudo cp "${runtime_log_location}" "${runtime_log_path}"
+
+	if [[ -n $(ps -p 1 | grep systemd) ]]; then
+		sudo journalctl --no-pager -u cc-proxy > "${proxy_log_path}"
+		sudo journalctl --no-pager -t cc-shim > "${shim_log_path}"
+		sudo journalctl --no-pager -u crio > "${crio_log_path}"
+	else
+		sudo cp "${upstart_proxy_path}" > "${proxy_log_path}"
+		sudo cp "${upstart_crio_path}" > "${crio_log_path}"
+	fi
 else
-	echo "Clear Containers Proxy Log:"
-	sudo journalctl --no-pager -u cc-proxy
-	echo "Clear Containers Shim Log:"
-	sudo journalctl --no-pager -t cc-shim
-	echo "CRI-O Log:"
-	sudo journalctl --no-pager -u crio
+	echo "Clear Containers Runtime Log:"
+	sudo cat "${runtime_log_location}"
+
+	if [[ -n $(ps -p 1 | grep systemd) ]]; then
+		echo "Clear Containers Proxy Log:"
+		sudo journalctl --no-pager -u cc-proxy
+		echo "Clear Containers Shim Log:"
+		sudo journalctl --no-pager -t cc-shim
+		echo "CRI-O Log:"
+		sudo journalctl --no-pager -u crio
+	else
+		echo "Clear Containers Proxy Log:"
+		sudo cat "${upstart_proxy_path}"
+		echo "CRI-O Log:"
+		sudo cat "${upstart_crio_path}"
+	fi
 fi

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -32,38 +32,20 @@ shim_log_path="${log_copy_dest}/${shim_log_filename}"
 crio_log_filename="crio.log"
 crio_log_path="${log_copy_dest}/${crio_log_filename}"
 
-upstart_logs_path="/var/log/upstart"
-upstart_proxy_path="${upstart_logs_path}/${proxy_log_filename}"
-upstart_crio_path="${upstart_logs_path}/${crio_log_filename}"
-
 # Copy log files if a destination path is provided, otherwise simply
 # display them.
 if [ ${log_copy_dest} ]; then
 	sudo cp "${runtime_log_location}" "${runtime_log_path}"
-
-	if [[ -n $(ps -p 1 | grep systemd) ]]; then
-		sudo journalctl --no-pager -u cc-proxy > "${proxy_log_path}"
-		sudo journalctl --no-pager -t cc-shim > "${shim_log_path}"
-		sudo journalctl --no-pager -u crio > "${crio_log_path}"
-	else
-		sudo cp "${upstart_proxy_path}" > "${proxy_log_path}"
-		sudo cp "${upstart_crio_path}" > "${crio_log_path}"
-	fi
+	sudo journalctl --no-pager -u cc-proxy > "${proxy_log_path}"
+	sudo journalctl --no-pager -t cc-shim > "${shim_log_path}"
+	sudo journalctl --no-pager -u crio > "${crio_log_path}"
 else
 	echo "Clear Containers Runtime Log:"
 	sudo cat "${runtime_log_location}"
-
-	if [[ -n $(ps -p 1 | grep systemd) ]]; then
-		echo "Clear Containers Proxy Log:"
-		sudo journalctl --no-pager -u cc-proxy
-		echo "Clear Containers Shim Log:"
-		sudo journalctl --no-pager -t cc-shim
-		echo "CRI-O Log:"
-		sudo journalctl --no-pager -u crio
-	else
-		echo "Clear Containers Proxy Log:"
-		sudo cat "${upstart_proxy_path}"
-		echo "CRI-O Log:"
-		sudo cat "${upstart_crio_path}"
-	fi
+	echo "Clear Containers Proxy Log:"
+	sudo journalctl --no-pager -u cc-proxy
+	echo "Clear Containers Shim Log:"
+	sudo journalctl --no-pager -t cc-shim
+	echo "CRI-O Log:"
+	sudo journalctl --no-pager -u crio
 fi


### PR DESCRIPTION
If a destination directory is provided to the teardown.sh script,
it will now copy the logs instead of displaying them through the
standard output. By default, if no path is provided, we keep the
original behavior, meaning we're dumping the logs.

Also, because our CI is not testing on Ubuntu 14.04 anymore,
there is no reason for keeping the upstart case handled by our
scripts.

Fixes #608