### PR TITLE
CI: Install packages from clearlinux.org instead of OBS (fedora)

### DIFF
--- a/.ci/install_qemu_lite.sh
+++ b/.ci/install_qemu_lite.sh
@@ -16,14 +16,15 @@
 
 set -e
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <CLEAR_RELEASE> <QEMU_LITE_VERSION>"
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <CLEAR_RELEASE> <QEMU_LITE_VERSION> <DISTRO>"
     echo "       Install the QEMU_LITE_VERSION from clear CLEAR_RELEASE."
     exit 1
 fi
 
 clear_release="$1"
 qemu_lite_version="$2"
+distro="$3"
 qemu_lite_bin="qemu-lite-bin-${qemu_lite_version}.x86_64.rpm"
 qemu_lite_data="qemu-lite-data-${qemu_lite_version}.x86_64.rpm"
 
@@ -33,9 +34,14 @@ echo -e "Install qemu-lite ${qemu_lite_version}"
 curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/${qemu_lite_bin}"
 curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/x86_64/os/Packages/${qemu_lite_data}"
 
-# install packages using alien
-sudo alien -i "./${qemu_lite_bin}"
-sudo alien -i "./${qemu_lite_data}"
+# install packages
+if [ "$distro" == "fedora" ]; then
+    sudo rpm -ihv "./${qemu_lite_bin}" --nodeps
+    sudo rpm -ihv "./${qemu_lite_data}" --nodeps
+elif [ "$distro" == "ubuntu" ];  then
+    sudo alien -i "./${qemu_lite_bin}"
+    sudo alien -i "./${qemu_lite_data}"
+fi
 
 # cleanup
 rm -f "./${qemu_lite_bin}"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -19,6 +19,7 @@ set -e
 cidir=$(dirname "$0")
 source "$cidir/../test-versions.txt"
 source /etc/os-release
+cc_kernel_path="/usr/share/clear-containers"
 
 if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
 	echo "enable Nested Virtualization"
@@ -27,23 +28,20 @@ if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
 fi
 
 sudo -E dnf -y install dnf-plugins-core
-sudo -E dnf config-manager --add-repo \
-http://download.opensuse.org/repositories/home:/clearcontainers:/clear-containers-3/Fedora_$VERSION_ID/home:clearcontainers:clear-containers-3.repo
-
 sudo -E dnf makecache
 
 echo "Install clear containers dependencies"
 sudo -E dnf -y groupinstall "Development tools"
-sudo -E dnf -y install libtool automake autoconf bc
+sudo -E dnf -y install libtool automake autoconf bc pixman numactl-libs
 
 echo "Install qemu-lite binary"
-sudo -E dnf -y install qemu-lite
+"${cidir}/install_qemu_lite.sh" "${qemu_clear_release}" "${qemu_lite_sha}" "$ID"
 
 echo "Install clear-containers image"
-sudo -E dnf -y install clear-containers-image
+"${cidir}/install_clear_image.sh" "$image_version" "${cc_kernel_path}"
 
 echo "Install Clear Containers Kernel"
-sudo -E dnf -y install linux-container
+"${cidir}/install_clear_kernel.sh" "${kernel_clear_release}" "${kernel_version}" "${cc_kernel_path}"
 
 echo "Install CRI-O dependencies"
 sudo -E dnf -y install btrfs-progs-devel device-mapper-devel \

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -37,7 +37,7 @@ echo "Install clear containers dependencies"
 chronic sudo -E apt install -y libtool automake autotools-dev autoconf bc alien libpixman-1-dev
 
 echo "Install qemu-lite binary"
-"${cidir}/install_qemu_lite.sh" "${qemu_clear_release}" "${qemu_lite_sha}"
+"${cidir}/install_qemu_lite.sh" "${qemu_clear_release}" "${qemu_lite_sha}" "$ID"
 
 echo "Install clear-containers image"
 "${cidir}/install_clear_image.sh" "$image_version" "${cc_kernel_path}"


### PR DESCRIPTION
This change install clear-containers-image, linux-container and
qemu-lite packages from download.clearlinux.org.

This change is to not rely on OBS platform as sometimes the service
is down.

Fixes #604

Signed-off-by: Geronimo Orozco <geronimo.orozco@intel.com>