### PR TITLE
cmd: checkmetrics: Add nobaseline option

### DIFF
--- a/cmd/checkmetrics/README.md
+++ b/cmd/checkmetrics/README.md
@@ -47,7 +47,7 @@ maxval = 1.5
 ## Options
 `checkmetrics` takes a number of options. Some are mandatory.
 
-### TOML basefile path (mandatory)
+### TOML basefile path (mandatory unless `nobaseline` is used)
 
 ```
 --basefile value    path to baseline TOML metrics file
@@ -61,6 +61,11 @@ maxval = 1.5
 ### Log file path
 ```
 --log value         set the log file path
+```
+
+### No baseline
+```
+--nobaseline        enable parsing metrics without a basefile
 ```
 
 ### Metrics CSV directory path

--- a/cmd/checkmetrics/csv.go
+++ b/cmd/checkmetrics/csv.go
@@ -39,6 +39,7 @@ type csvRecord struct {
 	MaxVal        float64   // Largest value we saw
 	SD            float64   // Standard Deviation
 	CoV           float64   // Co-efficient of Variation
+	TestName      string    // Test name field
 }
 
 // load reads in a CSV 'Metrics' results file from the file path given
@@ -75,6 +76,9 @@ func (c *csvRecord) load(filepath string) error {
 	// The Results column for the CSV metrics files is expected to be in the 5th column
 	const resultsColumn = 4
 
+	// The Test Name column for the CSV metrics files is expected to be in the 3rd column
+	const testNameColumn = 2
+
 	// Sanity check that the CSV file appears to have the Result column where
 	// we expect to find it
 	numZeroRecords := len(c.Records[0])
@@ -87,6 +91,9 @@ func (c *csvRecord) load(filepath string) error {
 		log.Errorf("Column %d is [%s], not [Result]", resultsColumn+1, c.Records[0][resultsColumn])
 		return errors.New("Expected Results column is not [Result]")
 	}
+
+	// Filter the test name
+	c.TestName = c.Records[1][testNameColumn]
 
 	// Build a slice containing just the 'Result' strings
 	for _, r := range c.Records {


### PR DESCRIPTION
This option allows to parse the metrics CSV files without
a baseline file, the report about these metrics just
includes the mean, the standard deviation and the number
of samples used for those results.

Fixes: #611