### PR TITLE
ci: Fix kubernetes tests by not testing with runc master

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -53,6 +53,7 @@ popd
 echo "Install runc for CRI-O"
 go get -d github.com/opencontainers/runc
 pushd "${GOPATH}/src/github.com/opencontainers/runc"
+git checkout "$runc_version"
 make
 sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
 popd

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,6 +1,9 @@
 # Well known working crio tag/commit/branch
 crio_version=400713a58bedb88678e84b72d4620847c8d27fec
 
+# Runc version compatible with crio_version
+runc_version=84a082bfef6f932de921437815355186db37aeb1
+
 # Clear Containers image version
 image_version=18220
 


### PR DESCRIPTION
Currently we test kubernetes with latest runc, but today the
compatibility with CRI-O got broken. This fix adds a
runc_version to ensure we have working builds.

Fixes: #615.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>