### PR TITLE
metrics: network: Add host/container test

### DIFF
--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -27,6 +27,9 @@
 #
 # case 1:
 #  container-server <----> container-client
+#
+# case 2"
+#  container-server <----> host-client
 
 set -e
 
@@ -276,6 +279,19 @@ function iperf_host_cnt_bwd_rev() {
 	parse_iperf_bwd "$test_name" "$result"
 }
 
+# This tests measures the bandwidth using different number of parallel
+# client streams. (2, 4, 8)
+function iperf_multiqueue() {
+	local test_name="network multiqueue"
+	local client_streams=("2" "4" "8")
+
+	for s in "${client_streams[@]}"; do
+		tn="$test_name $s"
+		result="$(get_host_cnt_bwd "-P $s")"
+		sum="$(echo "$result" | grep "SUM" | tail -n2)"
+		parse_iperf_bwd "$tn" "$sum"
+	done
+}
 
 echo "Currently this script is using ramfs for tmp (see https://github.com/01org/cc-oci-runtime/issues/152)"
 
@@ -288,5 +304,7 @@ iperf3_jitter
 iperf_host_cnt_bwd
 
 iperf_host_cnt_bwd_rev
+
+iperf_multiqueue
 
 iperf3_bidirectional_bandwidth_client_server

--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -218,6 +218,7 @@ function parse_iperf_bwd() {
 	save_results "${test_name} sender" "" "$tx_bwd" "$tx_uts"
 
 	# Show results
+	echo "$test_name"
 	echo "Receiver bandwidth $mode : $rx_bwd $rx_uts"
 	echo "Sender bandwidth $mode : $tx_bwd $tx_uts"
 
@@ -267,6 +268,14 @@ function iperf_host_cnt_bwd() {
 	parse_iperf_bwd "$test_name" "$result"
 }
 
+# This test is similar to "iperf_host_cnt_bwd", the difference is this
+# tests runs in reverse mode.
+function iperf_host_cnt_bwd_rev() {
+	local test_name="network bwd host contr reverse"
+	local result="$(get_host_cnt_bwd "-R")"
+	parse_iperf_bwd "$test_name" "$result"
+}
+
 
 echo "Currently this script is using ramfs for tmp (see https://github.com/01org/cc-oci-runtime/issues/152)"
 
@@ -277,5 +286,7 @@ iperf3_bandwidth
 iperf3_jitter
 
 iperf_host_cnt_bwd
+
+iperf_host_cnt_bwd_rev
 
 iperf3_bidirectional_bandwidth_client_server


### PR DESCRIPTION
This commits adds a test that measures the bandwidth
between a client/server interconnection, where
the container takes the role of server and the host
takes the role of client.

Fixes: #617

Signed-off-by: Arevalo, Mario Alfredo C <mario.alfredo.c.arevalo@intel.com>