### PR TITLE
metrics: Only systemctl restart once per cycle

### DIFF
--- a/.ci/run_metrics_ci.sh
+++ b/.ci/run_metrics_ci.sh
@@ -15,12 +15,17 @@
 # limitations under the License.
 
 CURRENTDIR=$(dirname "$(readlink -f "$0")")
+source "${CURRENTDIR}/../metrics/lib/common.bash"
+
 REPORT_CMDS=("checkmetrics" "emailreport")
 
 KSM_ENABLE_FILE="/sys/kernel/mm/ksm/run"
 GITHUB_URL="https://github.com"
 RESULTS_BACKUP_PATH="/var/local/localCI/backup"
 RESULTS_DIR="results"
+
+# Set up the initial state
+onetime_init
 
 # Verify/install report tools. These tools will
 # parse/send the results from metrics scripts execution.

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -65,6 +65,26 @@ function check_cmds()
 	done
 }
 
+# A one time (per uber test cycle) init that tries to get the
+# system to a 'known state' as much as possible
+function onetime_init()
+{
+	# The onetime init must be called once, and only once
+	if [ ! -z "$onetime_init_done" ]; then
+		die "onetime_init() called more than once"
+	fi
+
+	# Restart services
+	sudo systemctl restart docker
+	if [[ "${RUNTIME}" == "cor" || "${RUNTIME}" == "cc-runtime" ]];then
+		sudo systemctl restart cc-proxy
+	fi
+
+	# We want this to be seen in sub shells as well...
+	# otherwise init_env() cannot check us
+	export onetime_init_done=1
+}
+
 # Initialization/verification environment. This function makes
 # minimal steps for metrics/tests execution.
 function init_env()
@@ -80,12 +100,6 @@ function init_env()
 	# This clean up is more aggressive, this is in order to
 	# decrease the factors that could affect the metrics results.
 	kill_processes_before_start
-
-	# Restart services
-	sudo systemctl restart docker
-	if [[ "${RUNTIME}" == "cor" || "${RUNTIME}" == "cc-runtime" ]];then
-		sudo systemctl restart cc-proxy
-	fi
 }
 
 # Clean environment, this function will try to remove all

--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -19,6 +19,9 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib/common.bash"
 
+# Set up the initial state
+onetime_init
+
 # Check arguments
 if [[ ! -v RUNTIME ]]; then
     die Variable RUNTIME must be set to the name of your CC runtime


### PR DESCRIPTION
Rather than doing a systemctl restart on docker and the proxy
for every test invocation, lets just do it the once at the
start before we begin the test cycle.

Fix up the invocation scripts to make the one off call.

Predominanlty because running many frequent restarts on my
ubuntu machine results in systemd disabling docker.service
as it sees it as restarting too often.

Fixes: #619

Signed-off-by: Graham whaley <graham.whaley@intel.com>