### PR TITLE
20171019 clarify logs

### DIFF
--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -195,9 +195,8 @@ fi
 #Check for KSM before reporting test name, as it can modify it
 check_for_ksm
 
-echo "Executing Test: ${TEST_NAME}"
+init_env
 
 check_cmds "${SMEM_BIN}" bc
-init_env
 
 get_docker_memory_usage

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -85,10 +85,19 @@ function onetime_init()
 	export onetime_init_done=1
 }
 
+# Print a clear banner to the logs noting clearly which test
+# we are about to run
+function test_banner()
+{
+	echo -e "\n===== starting test [$1] ====="
+}
+
 # Initialization/verification environment. This function makes
 # minimal steps for metrics/tests execution.
 function init_env()
 {
+	test_banner "${TEST_NAME}"
+
 	cmd=("docker")
 
 	# check dependencies

--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -31,6 +31,8 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib/network-common.bash"
 source "${SCRIPT_PATH}/../lib/common.bash"
 
+TEST_NAME="iperf3 tests"
+
 # Port number where the server will run
 port="5201:5201"
 # Image name
@@ -145,9 +147,9 @@ function iperf3_bidirectional_bandwidth_client_server() {
 	echo "Finish"
 }
 
-echo "Currently this script is using ramfs for tmp (see https://github.com/01org/cc-oci-runtime/issues/152)"
-
 init_env
+
+echo "Currently this script is using ramfs for tmp (see https://github.com/01org/cc-oci-runtime/issues/152)"
 
 iperf3_bandwidth
 

--- a/metrics/network/network-metrics-nuttcp.sh
+++ b/metrics/network/network-metrics-nuttcp.sh
@@ -26,6 +26,7 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib/network-common.bash"
 source "${SCRIPT_PATH}/../lib/common.bash"
 
+TEST_NAME="nuttcp tests"
 
 function udp_bandwidth() {
 	# Currently default nuttcp has a bug

--- a/metrics/network/network-metrics.sh
+++ b/metrics/network/network-metrics.sh
@@ -26,6 +26,8 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib/network-common.bash"
 source "${SCRIPT_PATH}/../lib/common.bash"
 
+TEST_NAME="iperf2 tests"
+
 # Extract bandwidth results for both directions from the one test
 function bidirectional_bandwidth_server_client() {
 	# Port number where the server will run

--- a/metrics/network/network-nginx-ab-benchmark.sh
+++ b/metrics/network/network-nginx-ab-benchmark.sh
@@ -41,14 +41,15 @@ requests=100000
 concurrency=100
 
 function nginx_ab_networking() {
-	# Verify apache benchmark
-	cmds=("ab")
-	check_cmds "${cmds[@]}"
 	extra_args=" -p $port"
 	total_requests="tmp.log"
 
 	# Initialize/clean environment
 	init_env
+
+	# Verify apache benchmark
+	cmds=("ab")
+	check_cmds "${cmds[@]}"
 
 	# Launch nginx container
 	$DOCKER_EXE run -d -p $port $image

--- a/metrics/storage/fio_job.sh
+++ b/metrics/storage/fio_job.sh
@@ -153,8 +153,8 @@ function main()
 	done
 	shift $((OPTIND-1))
 
-	check_cmds "${cmds[@]}"
 	init_env
+	check_cmds "${cmds[@]}"
 	create_fio_job
 
 	# Launch container

--- a/metrics/time/docker_workload_time.sh
+++ b/metrics/time/docker_workload_time.sh
@@ -68,7 +68,7 @@ function run_workload(){
 	rm -f $TMP_FILE
 }
 
-echo "Executing test: ${TEST_NAME} ${TEST_ARGS}"
+init_env
 prewarm
 for i in $(seq 1 "$TIMES"); do
 	run_workload


### PR DESCRIPTION
Add function and call from init_env to notify which tests we are running when,
and fix up relevant places in tests to set the TEST_NAME var and call init_env as early as practical
in each test.