### PR TITLE
.ci: Split log files to avoid getting too large ones

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -22,30 +22,45 @@ log_copy_dest="$1"
 runtime_log_location="/var/lib/clear-containers/runtime/runtime.log"
 runtime_log_filename="cc-runtime.log"
 runtime_log_path="${log_copy_dest}/${runtime_log_filename}"
+runtime_log_prefix="cc-runtime_"
 
 proxy_log_filename="cc-proxy.log"
 proxy_log_path="${log_copy_dest}/${proxy_log_filename}"
+proxy_log_prefix="cc-proxy_"
 
 shim_log_filename="cc-shim.log"
 shim_log_path="${log_copy_dest}/${shim_log_filename}"
+shim_log_prefix="cc-shim_"
 
 crio_log_filename="crio.log"
 crio_log_path="${log_copy_dest}/${crio_log_filename}"
+crio_log_prefix="crio_"
 
 # Copy log files if a destination path is provided, otherwise simply
 # display them.
 if [ ${log_copy_dest} ]; then
+	# Create the log files
 	sudo cp "${runtime_log_location}" "${runtime_log_path}"
-	sudo journalctl --no-pager -u cc-proxy > "${proxy_log_path}"
-	sudo journalctl --no-pager -t cc-shim > "${shim_log_path}"
-	sudo journalctl --no-pager -u crio > "${crio_log_path}"
+	sudo chown ${USER}:${USER} "${runtime_log_path}"
+	journalctl --no-pager -u cc-proxy > "${proxy_log_path}"
+	journalctl --no-pager -t cc-shim > "${shim_log_path}"
+	journalctl --no-pager -u crio > "${crio_log_path}"
+
+	# Split them in 5 MiB subfiles to avoid too large files.
+	subfile_size=5242880
+	pushd ${log_copy_dest}
+	split -b ${subfile_size} -d ${runtime_log_path} ${runtime_log_prefix}
+	split -b ${subfile_size} -d ${proxy_log_path} ${proxy_log_prefix}
+	split -b ${subfile_size} -d ${shim_log_path} ${shim_log_prefix}
+	split -b ${subfile_size} -d ${crio_log_path} ${crio_log_prefix}
+	popd
 else
 	echo "Clear Containers Runtime Log:"
 	sudo cat "${runtime_log_location}"
 	echo "Clear Containers Proxy Log:"
-	sudo journalctl --no-pager -u cc-proxy
+	journalctl --no-pager -u cc-proxy
 	echo "Clear Containers Shim Log:"
-	sudo journalctl --no-pager -t cc-shim
+	journalctl --no-pager -t cc-shim
 	echo "CRI-O Log:"
-	sudo journalctl --no-pager -u crio
+	journalctl --no-pager -u crio
 fi


### PR DESCRIPTION
In case of Jenkins CI, we need to have log files not too large
so that they can be properly moved from the VM to the Jenkins
server as build artifacts. Also, 5 MiB is a reasonable size to
check those logs from a web browser.

Notice that "sudo" has been removed from this script since none
of them were really needed. Moreover, the copy of the runtime
logs with "sudo" was preventing the regular user to modify the
file previously copied.

Fixes #627