### PR TITLE
.ci: Enable devicemapper for CRIO

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -17,6 +17,10 @@
 set -e
 source /etc/os-release
 
+if [ "$ID" == "ubuntu" ] && [ "$VERSION_ID" == "17.04" ]; then
+	export CRIO_STORAGE_DRIVER_OPTS="--storage-driver=devicemapper"
+fi
+
 sudo -E PATH="$PATH" bash -c "make check"
 
 # Currently, Openshift tests only work on Fedora.

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ crio:
 	bash .ci/install_bats.sh
 	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
 	cd ${CRIO_REPO_PATH} && \
-	RUNTIME=${RUNTIME} ./test/test_runner.sh crio.bats
+	RUNTIME=${RUNTIME} STORAGE_OPTS="${CRIO_STORAGE_DRIVER_OPTS}" ./test/test_runner.sh crio.bats
 
 ginkgo:
 	ln -sf . vendor/src


### PR DESCRIPTION
This commit enables devicemapper for CRIO testing.

Fixes #633