### PR TITLE
integration: Use docker with user defined runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Path of Clear Containers Runtime
-CC_RUNTIME ?= cc-runtime
+RUNTIME ?= cc-runtime
 
 # The time limit in seconds for each test
 TIMEOUT ?= 15
@@ -23,7 +23,7 @@ crio:
 	bash .ci/install_bats.sh
 	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
 	cd ${CRIO_REPO_PATH} && \
-	RUNTIME=${CC_RUNTIME} ./test/test_runner.sh crio.bats
+	RUNTIME=${RUNTIME} ./test/test_runner.sh crio.bats
 
 ginkgo:
 	ln -sf . vendor/src
@@ -31,13 +31,13 @@ ginkgo:
 	unlink vendor/src
 
 functional: ginkgo
-	./ginkgo -v functional/ -- -runtime ${CC_RUNTIME} -timeout ${TIMEOUT}
+	./ginkgo -v functional/ -- -runtime ${RUNTIME} -timeout ${TIMEOUT}
 
 metrics:
-	RUNTIME=${CC_RUNTIME} ./metrics/run_all_metrics.sh
+	RUNTIME=${RUNTIME} ./metrics/run_all_metrics.sh
 
 integration: ginkgo
-	./ginkgo -v -focus "${FOCUS}" ./integration/docker/ -- -runtime=${CC_RUNTIME} -timeout ${TIMEOUT}
+	./ginkgo -v -focus "${FOCUS}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout ${TIMEOUT}
 
 openshift:
 	bash .ci/install_bats.sh

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ ginkgo:
 	unlink vendor/src
 
 functional: ginkgo
-	./ginkgo functional/ -- -runtime ${CC_RUNTIME} -timeout ${TIMEOUT}
+	./ginkgo -v functional/ -- -runtime ${CC_RUNTIME} -timeout ${TIMEOUT}
 
 metrics:
 	RUNTIME=${CC_RUNTIME} ./metrics/run_all_metrics.sh
 
 integration: ginkgo
-	./ginkgo ./integration/docker/ -- -runtime=${CC_RUNTIME} -timeout ${TIMEOUT}
+	./ginkgo -v -focus "${FOCUS}" ./integration/docker/ -- -runtime=${CC_RUNTIME} -timeout ${TIMEOUT}
 
 openshift:
 	bash .ci/install_bats.sh

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ metrics:
 	RUNTIME=${CC_RUNTIME} ./metrics/run_all_metrics.sh
 
 integration: ginkgo
-	./ginkgo ./integration/docker/ -- -timeout ${TIMEOUT}
+	./ginkgo ./integration/docker/ -- -runtime=${CC_RUNTIME} -timeout ${TIMEOUT}
 
 openshift:
 	bash .ci/install_bats.sh

--- a/docker.go
+++ b/docker.go
@@ -161,6 +161,13 @@ func DockerPull(args ...string) (string, string, int) {
 
 // DockerRun runs a container
 func DockerRun(args ...string) (string, string, int) {
+	if Runtime != "" {
+		args = append(args, []string{"", ""}...)
+		copy(args[2:], args[:])
+		args[0] = "--runtime"
+		args[1] = Runtime
+	}
+
 	return runDockerCommand("run", args...)
 }
 

--- a/integration/docker/info_test.go
+++ b/integration/docker/info_test.go
@@ -30,7 +30,7 @@ var _ = Describe("info", func() {
 		It("should has a runtime information", func() {
 			stdout, _, exitCode = DockerInfo()
 			Expect(exitCode).To(Equal(0))
-			Expect(stdout).NotTo(ContainSubstring("Default Runtime: runc"))
+			Expect(stdout).To(ContainSubstring("Default Runtime: " + Runtime))
 		})
 	})
 })


### PR DESCRIPTION
Use CC_RUNTIME variable from Makefile instead of expect
the cc-runtime defined as default runtime in docker.

The PR also  adds two ginkgo options.

- verbose:

Add `-v` option to ginkgo in order to know what commands
are being running on each tests and not only the lines of
ginkgo.

- focus:

Added -fucus option allow to only run some tests.

Example:
```
make integration FOCUS="docker kill"
```
will run only docker kill tests

- Changed `CC_RUNTIME` variable name to `RUNTIME`

Fixes: #637

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>