### PR TITLE
Azure: Fixes to docker and crio setup

### DIFF
--- a/Azure/cc-setup-azure.sh
+++ b/Azure/cc-setup-azure.sh
@@ -29,8 +29,6 @@ VM_ADMIN_USER="adminazure"
 GRP_LOCATION="eastus"
 
 # Disks configuration
-DISK_NAME="${VM_NAME}_devmapper"
-DISK_NAME_CRIO="${VM_NAME}_devmapper_crio"
 DISK_CACHING="ReadWrite"
 
 # This disk size was selected due to it gets
@@ -157,6 +155,8 @@ function main() {
 	shift $((OPTIND-1))
 
 	# Execute azure/VM creation flow
+	DISK_NAME="${VM_NAME}_devmapper"
+	DISK_NAME_CRIO="${VM_NAME}_devmapper_crio"
 	create_group
 	create_dvm_disk
 	create_dvm_crio_disk

--- a/Azure/cloud-init.txt
+++ b/Azure/cloud-init.txt
@@ -73,17 +73,9 @@ apt-get install -y thin-provisioning-tools
 
 # Configure the clear containers runtime using devicemapper as
 # storage driver
-mkdir -p /etc/systemd/system/docker.service.d/
-cat <<EOF | tee /etc/systemd/system/docker.service.d/clr-containers.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd -D --add-runtime cc-runtime=/usr/bin/cc-runtime --default-runtime=cc-runtime
-EOF
-
-# Add devicemapper configuration
 mkdir -p /etc/docker
-
 mkdir -p /etc/lvm/profile
+
 cat <<EOF | tee /etc/docker/daemon.json
 {
 "storage-driver": "devicemapper",
@@ -94,7 +86,13 @@ cat <<EOF | tee /etc/docker/daemon.json
         "dm.thinp_autoextend_threshold=80",
         "dm.thinp_autoextend_percent=20",
         "dm.directlvm_device_force=true"
-]
+],
+"default-runtime": "cc-runtime",
+	"runtimes": {
+		"cc-runtime": {
+			"path": "/usr/bin/cc-runtime"
+		}
+	}
 }
 EOF
 
@@ -194,6 +192,7 @@ WantedBy=multi-user.target
 EOF
 
 # Configure CRI-O
+sed -i 's/storage_driver = ""/storage_driver = \"devicemapper"/' "/etc/crio/crio.conf"
 sed -i 's/storage_option = \[/storage_option = \["dm.directlvm_device=\/dev\/sdd", "dm.thinp_percent=95", "dm.thinp_metapercent=1", "dm.thinp_autoextend_threshold=80", "dm.thinp_autoextend_percent=20", "dm.directlvm_device_force=true"/' "/etc/crio/crio.conf"
 sed -i 's/runtime = "\/usr\/bin\/runc"/runtime = "\/usr\/lib\/cri-o-runc\/sbin\/runc"/' "/etc/crio/crio.conf"
 sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/bin\/cc-runtime"/' "/etc/crio/crio.conf"


### PR DESCRIPTION
- Use daemon.json to setup the runtime instead of a systemd unit file.
  This allows the distro defaults to be preserved.

- Set the default graph driver to devicemapper

- Also ensure that each VM gets its own unique set of disks.
  This allows the script to be run multiple times as long as the
  VM name is unique

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>