### PR TITLE
ci: integration: Fix docker kill tests

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -53,6 +53,19 @@ func runDockerCommand(command string, args ...string) (string, string, int) {
 	return runDockerCommandWithTimeout(time.Duration(Timeout), command, args...)
 }
 
+// LogsDockerContainer returns the container logs
+func LogsDockerContainer(name string) (string, error) {
+	args := []string{name}
+
+	stdout, _, exitCode := runDockerCommand("logs", args...)
+
+	if exitCode != 0 {
+		return "", fmt.Errorf("failed to run docker logs command")
+	}
+
+	return strings.TrimSpace(stdout), nil
+}
+
 // StatusDockerContainer returns the container status
 func StatusDockerContainer(name string) string {
 	args := []string{"-a", "-f", "name=" + name, "--format", "{{.Status}}"}

--- a/integration/docker/kill_test.go
+++ b/integration/docker/kill_test.go
@@ -16,6 +16,7 @@ package docker
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 	"time"
 
@@ -78,19 +79,47 @@ var _ = Describe("docker kill", func() {
 					"https://github.com/clearcontainers/runtime/issues/768")
 			}
 
+			trapTag := "TRAP_RUNNING"
+			trapCmd := fmt.Sprintf("trap \"exit %d\" %d; echo %s", signal, signal, trapTag)
+			infiniteLoop := "while :; do sleep 1; done"
+
 			if signal > 0 {
-				args = append(args, fmt.Sprintf("trap \"exit %d\" %d ; while : ; do sleep 1; done", signal, signal))
+				args = append(args, fmt.Sprintf("%s; %s", trapCmd, infiniteLoop))
 			} else {
-				args = append(args, fmt.Sprintf("while : ; do sleep 1; done"))
+				args = append(args, infiniteLoop)
 			}
 
 			DockerRun(args...)
 
-			// we have to wait for the container workload
-			// to process the trap.
-			time.Sleep(5 * time.Second)
-
 			if signal > 0 {
+				exitCh := make(chan bool)
+
+				go func() {
+					for {
+						// Don't check for error here since the command
+						// can fail if the container is not running yet.
+						logs, _ := LogsDockerContainer(id)
+						if strings.Contains(logs, trapTag) {
+							break
+						}
+
+						time.Sleep(time.Second)
+					}
+
+					close(exitCh)
+				}()
+
+				var err error
+
+				select {
+				case <-exitCh:
+					err = nil
+				case <-time.After(time.Duration(Timeout)*time.Second):
+					err = fmt.Errorf("Timeout reached after %ds", Timeout)
+				}
+
+				Expect(err).ToNot(HaveOccurred())
+
 				DockerKill("-s", fmt.Sprintf("%d", signal), id)
 			} else {
 				DockerKill(id)


### PR DESCRIPTION
Recently, the CI has been failing pretty often when running docker
kill tests. This is due to the way the tests are written. Indeed,
because the exit code is retrieved after a time.Sleep(), it does
not ensure the container has properly exited.

This patch inspects State.Status from the container, that way it
makes sure to retrieve the container exit code only after the
container has exited. With this way to proceed, we will never
read an exit code if it is not ready to be read.

Fixes #658