### PR TITLE
ci: Allow larger timeout for functional and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 RUNTIME ?= cc-runtime
 
 # The time limit in seconds for each test
-TIMEOUT ?= 15
+TIMEOUT ?= 60
 
 CRIO_REPO_PATH="${GOPATH}/src/github.com/kubernetes-incubator/cri-o"
 crio:


### PR DESCRIPTION
Our CI runs on Azure virtual machines and sometimes a simple docker
command can take some time because of the VM nesting. Let's increase
this timeout to avoid any false failure, which is going to make our
CI more stable.

Fixes #660