### PR TITLE
ci: update cri-o version to 1.0.2

### DIFF
--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,5 +1,5 @@
 # Well known working crio tag/commit/branch
-crio_version=v1.0.0
+crio_version=v1.0.2
 
 # Runc version compatible with crio_version
 runc_version=84a082bfef6f932de921437815355186db37aeb1


### PR DESCRIPTION
This commit updates CRI-O to the new release v1.0.2 for
testing Clear Containers.

Fixes #662.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>