### PR TITLE
ci: integration: Apply docker timeouts to most tests

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -33,10 +33,6 @@ const (
 
 	// PostgresImage is the postgres image
 	PostgresImage = "postgres"
-
-	// timeout for docker rmi command
-	// 15 seconds should be enough to complete this task
-	dockerRmiTimeout = 15
 )
 
 func runDockerCommandWithTimeout(timeout time.Duration, command string, args ...string) (string, string, int) {
@@ -219,7 +215,7 @@ func DockerRm(args ...string) (string, string, int) {
 // returns true on success else false
 func DockerStop(args ...string) (string, string, int) {
 	// docker stop takes ~15 seconds
-	return runDockerCommandWithTimeout(15, "stop", args...)
+	return runDockerCommand("stop", args...)
 }
 
 // DockerPull downloads the specific image
@@ -252,8 +248,7 @@ func DockerVolume(args ...string) (string, string, int) {
 
 // DockerAttach attach to a running container
 func DockerAttach(args ...string) (string, string, int) {
-	// 15 seconds should be enough to wait for the container workload
-	return runDockerCommandWithTimeout(15, "attach", args...)
+	return runDockerCommand("attach", args...)
 }
 
 // DockerCommit creates a new image from a container's changes
@@ -271,7 +266,7 @@ func DockerRmi(args ...string) (string, string, int) {
 	// docker takes more than 5 seconds to remove an image, it depends
 	// of the image size and this operation does not involve to the
 	// runtime
-	return runDockerCommandWithTimeout(dockerRmiTimeout, "rmi", args...)
+	return runDockerCommand("rmi", args...)
 }
 
 // DockerCp copies files/folders between a container and the local filesystem


### PR DESCRIPTION
We have recently bumped the global timeout from 15s to 60s, and
for all the cases (except docker pull), there is no reason to
apply specific timeouts.

Moreover, this is solving some sporadic issues related to the call
of docker stop. The reason is that docker stop uses SIGTERM first
and after 10s, if the process is still running, it sends SIGHUP.
In both runc and cc-runtime cases, we rely on libcontainer, and
there is a limitation about libcontainer for SIGTERM signal, in
such way that it won't terminate the running process even if the
process receives it.

For those cases, a timeout of 15s for docker stop is too low since
the process has only 5s remaining to really kill and stop everything.

Fixes #664