### PR TITLE
ci: jenkins: Use Jenkins workspace for GOPATH

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -20,11 +20,22 @@ set -e
 cc_repo=$1
 
 tests_repo="github.com/clearcontainers/tests"
-mkdir -p ${HOME}/go
+
+# This script is intended to execute under Jenkins
+# If we do not know where the Jenkins defined WORKSPACE area is
+# then quit
+if [ -z "${WORKSPACE}" ]
+then
+	echo "Jenkins WORKSPACE env var not set - exiting" >&2
+	exit 1
+fi
+
+# Put our go area into the Jenkins job WORKSPACE tree
+export GOPATH=${WORKSPACE}/go
+mkdir -p ${GOPATH}
 
 # Export all environment variables needed.
 export GOROOT="/usr/local/go"
-export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:${PATH}
 
 # Download and build goveralls binary in case we need to submit the code

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -26,7 +26,6 @@ mkdir -p ${HOME}/go
 export GOROOT="/usr/local/go"
 export GOPATH=${HOME}/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:${PATH}
-export CI=true
 
 # Download and build goveralls binary in case we need to submit the code
 # coverage.


### PR DESCRIPTION
We had our GOPATH being created/set to our home dir. That worked
fine for short lived Jenkins VMs currently utilised for the QA CI,
but might not be suitable for longer lived Jenkins slaves or ones
that perform parallel runs.
Jenkins provides a defined ${WORKSPACE} for each job - use that
location for GOPATH - which will also give us the benefit of
dropping and cleaning up properly if we ever use the 'remove
workspace after completion' feature of Jenkins.

Fixes: #667

Signed-off-by: Graham Whaley <graham.whaley@intel.com>