### PR TITLE
versions: Update image to 18770

### DIFF
--- a/test-versions.txt
+++ b/test-versions.txt
@@ -5,7 +5,7 @@ crio_version=v1.0.0
 runc_version=84a082bfef6f932de921437815355186db37aeb1
 
 # Clear Containers image version
-image_version=18520
+image_version=18770
 
 # Kernel Version to use on recent Linux Distros
 kernel_clear_release=18670


### PR DESCRIPTION
version: 18580

  Changes in package systemd (from 234-150 to 234-151):
    Auke Kok - Don't crash network-wait-online.
    https://download.clearlinux.org/releases/18580/clear/RELEASENOTES

version: 18590

  Changes in package systemd (from 234-151 to 234-153):
    Arjan van de Ven - version bump from 234-152 to 234-153
    Arjan van de Ven - clean up services to be with their binaries
    https://download.clearlinux.org/releases/18590/clear/RELEASENOTES

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>