### PR TITLE
metrics: network: drop -ti docker args

### DIFF
--- a/metrics/network/network-latency.sh
+++ b/metrics/network/network-latency.sh
@@ -34,8 +34,8 @@ function latency() {
 	# Number of packets (sent)
 	local number=10
 	# Arguments to run the client/server
-	local client_extra_args="-ti --rm"
-	local server_extra_args="-i"
+	local client_extra_args="--rm"
+	local server_extra_args=""
 
 	# Initialize/clean environment
 	init_env

--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -55,7 +55,7 @@ if [ "$RUNTIME" == "runc" ]; then
 fi
 
 # Client/Server extra configuration
-client_extra_args="-ti $extra_capability --rm"
+client_extra_args="$extra_capability --rm"
 server_extra_args="$extra_capability"
 
 # Iperf server configuration

--- a/metrics/network/network-metrics-nuttcp.sh
+++ b/metrics/network/network-metrics-nuttcp.sh
@@ -39,8 +39,8 @@ function udp_bandwidth() {
 	local server_name="network-server"
 
 	# Arguments to run the client/server
-	local server_extra_args="-i --name=$server_name"
-	local client_extra_args="-ti --rm"
+	local server_extra_args="--name=$server_name"
+	local client_extra_args="--rm"
 
 	# Initialize/clean environment
 	init_env

--- a/metrics/network/network-metrics.sh
+++ b/metrics/network/network-metrics.sh
@@ -38,7 +38,7 @@ function bidirectional_bandwidth_server_client() {
 	local transmit_timeout=5
 
 	# Arguments to run the client
-	local extra_args="-ti --rm"
+	local extra_args="--rm"
 
 	# Initialize/clean environment
 	init_env


### PR DESCRIPTION
Don't request terminal and interactive (-ti) features from docker
run when they are not requited. Requesting them when run under
'headless' (terminal-less) CI systems makes the tests fail with a
'not a tty' type error.

The tests run fine without these args, the data is returned and the
results files still generated.

Fixes: #671

Signed-off-by: Graham Whaley <graham.whaley@intel.com>