### PR TITLE
metrics: Add remote iperf3 bandwidth test

### DIFF
--- a/metrics/network/remote_network/README.md
+++ b/metrics/network/remote_network/README.md
@@ -1,0 +1,34 @@
+# Clear Containers remote networking test
+
+- The`remote-networking-iperf3.sh` script measures bandwidth using `iperf3` using a remote setup. Host A will run 
+a container that will act as a server while host B will run a container that will act as a client. 
+The network bandwidth will be measured across the containers.
+
+## Prerequisite
+
+An automatic login from host A (user A) to host B (user B) is needed. You must setup authentication 
+keys to do an ssh login without password.
+
+## Running the remote networking test
+
+`remote-networking-iperf3.sh` should run in host A. The script needs the following inputs to run:
+- Argument of the test to run. In this case this argument is `-b`.
+- Interface name where swarm will run.
+- User of the host B.
+- IP address of the host B.
+
+The `remote-networking-iperf3.sh` test may be run manually:
+
+```
+$ cd metrics/network/remote_network
+$ bash remote-networking-iperf3.sh "[options]" "<interface_name>" "<user>" "<ip_address>"
+
+```
+
+This is an example of how to run this script:
+
+```
+$ cd metrics/network/remote_network
+$ bash remote-networking-iperf3.sh -b -i eno1 -u tester -a 10.xxx.xxx.xxx
+
+```

--- a/metrics/network/remote_network/remote-networking-iperf3.sh
+++ b/metrics/network/remote_network/remote-networking-iperf3.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script will measure network bandwidth with iperf3 tool using a
+# remote setup, where host A will run a server container and host B will
+# run a client container.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/remote-networking-test-common.sh"
+
+# Time to run the server using iperf3
+server_time=30
+
+# This function describes how to use this script
+function help {
+echo "$(cat << EOF
+Usage: $0 "[options]"
+	Description:
+		This script will measure network bandwidth with iperf3
+		tool using a remote setup, where host A will run a server
+		container and host B will run a client container. In order
+		to run this script, these inputs are needed:
+		- The interface name where swarm will run.
+		- The user of the host B.
+		- The IP address of the host B
+	Options:
+		-h	Shows help
+		-b	Run remote bandwidth
+		-i	Interface name to run Swarm (mandatory)
+		-u	User of host B (mandatory)
+		-a	IP address of host B (mandatory)
+
+EOF
+)"
+}
+
+# This function will measure the bandwidth using iperf3
+function remote_network_bandwidth_iperf3 {
+	setup_swarm
+	client_replica_status
+	server_replica_status
+
+	server_ip_address=$(check_server_address)
+	start_server
+
+	client_id=$($DOCKER_EXE ps -q)
+	client_command="mount -t ramfs -o size=20M ramfs /tmp && iperf3 -c $server_ip_address -t $server_time"
+	result=$(start_client "$client_id" "$client_command")
+	total_bandwidth=$(echo "$result" | tail -n 3 | head -1 | awk '{print $(NF-2), $(NF-1)}')
+	echo "Network bandwidth is : $total_bandwidth"
+
+	clean_environment
+}
+
+function main {
+	local OPTIND
+	while getopts "hbj:i:u:a" opt
+	do
+		case "${opt}" in
+		h)
+			help
+			exit 0;
+		;;
+		b)
+			bandwidth_test="1"
+		;;
+		i)
+			interface_name="${OPTARG}"
+		;;
+		u)
+			ssh_user="${OPTARG}"
+		;;
+		a)
+			ssh_address="${OPTARG}"
+                ;;
+		esac
+		shift
+	done
+	shift $((OPTIND-1))
+
+	[ -z "$ssh_address" ] && help && die "Mandatory IP address of host B not supplied"
+	[ -z "$ssh_user" ] && help && die "Mandatory user of host B not supplied"
+	[ -z "$interface_name" ] && help && die "Mandatory interface name to run Swarm not supplied"
+
+	if [ "$bandwidth_test" == "1" ]; then
+		remote_network_bandwidth_iperf3
+	else
+		exit 0
+	fi
+}
+main "$@"

--- a/metrics/network/remote_network/remote-networking-test-common.sh
+++ b/metrics/network/remote_network/remote-networking-test-common.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file contains functions that are shared among the networking
+# tests that are using iperf
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../lib/common.bash"
+
+# Argument of the test to run
+argument="$1"
+# Name of the interface were swarm will run
+interface_name="$3"
+# Name of the user (ssh)
+ssh_user="$5"
+# Ip address (ssh)
+ssh_address="$7"
+# Image for network testing
+network_image="gabyct/network"
+# Number of replicas that will be launch in each host
+number_of_replicas=1
+# Timeout in seconds to verify replicas are running
+timeout=10
+# Name of the first service
+first_service="testswarm1"
+# Name of the second service
+second_service="testswarm2"
+# Port where the first service will run
+port_first_service="8080:80"
+# Port where the second service will run
+port_second_service="8081:80"
+
+# This function will start swarm as well as it will label
+# the nodes and create the replicas
+function setup_swarm {
+	token=$($DOCKER_EXE swarm init --advertise-addr "$interface_name")
+	token_name=$(echo "$token" | grep "token" | head -1 | cut -d '\' -f1)
+	ip_name=$(echo "$token" | grep ":" | tail -1)
+	ssh "$ssh_user"@"$ssh_address" "$DOCKER_EXE swarm join $token_name $ip_name"
+	first_node=$($DOCKER_EXE node ls -q | head -1)
+	second_node=$($DOCKER_EXE node ls -q | tail -1)
+	$DOCKER_EXE node update --label-add machine=machine1 "$first_node"
+	$DOCKER_EXE node update --label-add machine=machine2 "$second_node"
+	$DOCKER_EXE service create \
+		--name "$first_service" --replicas "$number_of_replicas" \
+		--constraint 'node.labels.machine == machine1' \
+		--publish "$port_first_service" "$network_image" sh
+	$DOCKER_EXE service create \
+		--name "second_service" --replicas "$number_of_replicas" \
+		--constraint 'node.labels.machine == machine2' \
+		--publish "$port_second_service" "$network_image" sh
+}
+
+# This function will verify that the replica on the host client is running
+function client_replica_status {
+	for i in $(seq "$timeout"); do
+		client_status=$($DOCKER_EXE ps -q --filter=status=running | wc -l)
+		if [ "$client_status" -ge "$number_of_replicas" ]; then
+			break
+		fi
+		sleep 1
+	done
+}
+
+# This function will verify that the replica on the host server is running
+function server_replica_status {
+	for i in $(seq "$timeout"); do
+		status=$(ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
+		$DOCKER_EXE ps -q --filter=status=running | wc -l')
+		if [ "$status" -ge "$number_of_replicas" ]; then
+			break
+		fi
+		sleep 1
+	done
+}
+
+# This function will verify the ip address of the server
+function check_server_address {
+	ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
+			network_name=$($DOCKER_EXE network ls --filter driver=overlay -q); \
+			$DOCKER_EXE network inspect "$network_name" --format "{{ range .Containers}} \
+			{{ println .IPv4Address}}{{end}}" | head -n -2 | cut -d'/' -f1'
+}
+
+# This function will start an iperf3 server
+function start_server {
+	ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
+			server_id=$($DOCKER_EXE ps -q); \
+			server_command="mount -t ramfs -o size=20M ramfs /tmp && iperf3 -s"; \
+			$DOCKER_EXE exec -d "$server_id" sh -c "$server_command"'
+}
+
+# This function will start an iperf3 client
+function start_client {
+	client_id="$1"
+	client_command="$2"
+	$DOCKER_EXE exec "$client_id" sh -c "$client_command"
+}
+
+# This function will remove swarm on both client and server hosts
+function clean_environment {
+	$DOCKER_EXE swarm leave --force
+	ssh "$ssh_user"@"$ssh_address" "$DOCKER_EXE swarm leave --force"
+}


### PR DESCRIPTION
Add remote bandwidth test using iperf3. Where one host will run
a container that will act as a client and another host will run
a container that will act as a server and bandwidth will be
measure across the containers.

Fixes #673

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>