### PR TITLE
ci: integration: Fix docker restart

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -145,6 +145,26 @@ func ExitCodeDockerContainer(name string, waitForExit bool) (int, error) {
 	return strconv.Atoi(strings.TrimSpace(stdout))
 }
 
+func WaitForRunningDockerContainer(name string, running bool) error {
+	ch := make(chan bool)
+	go func() {
+		if IsRunningDockerContainer(name) == running {
+			close(ch)
+			return
+		}
+
+		time.Sleep(time.Second)
+	}()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Duration(Timeout)*time.Second):
+		return fmt.Errorf("Timeout reached after %ds", Timeout)
+	}
+
+	return nil
+}
+
 // IsRunningDockerContainer inspects a container
 // returns true if is running
 func IsRunningDockerContainer(name string) bool {

--- a/integration/docker/restart_test.go
+++ b/integration/docker/restart_test.go
@@ -41,10 +41,10 @@ var _ = Describe("restart", func() {
 		Context("restart a container", func() {
 			It("should be running", func() {
 				Expect(StopDockerContainer(id)).To(BeTrue())
-				Expect(IsRunningDockerContainer(id)).To(BeFalse())
+				Expect(WaitForRunningDockerContainer(id, false)).To(BeNil())
 				args = []string{"restart", id}
 				runDockerCommand(0, args...)
-				Expect(IsRunningDockerContainer(id)).To(BeTrue())
+				Expect(WaitForRunningDockerContainer(id, true)).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
This test introduces some timeouts in order to let the container to
be properly stopped before it tries to restart it. Expected status
might sometimes take some time to be set and we should not error in
case we don't get the expected status on the first try.

Fixes #680