### PR TITLE
versions: Update image to version 18860

### DIFF
--- a/test-versions.txt
+++ b/test-versions.txt
@@ -5,7 +5,7 @@ crio_version=v1.0.0
 runc_version=84a082bfef6f932de921437815355186db37aeb1
 
 # Clear Containers image version
-image_version=18770
+image_version=18860
 
 # Kernel Version to use on recent Linux Distros
 kernel_clear_release=18670


### PR DESCRIPTION
Changes:

version: 18800
Changes in package clear-containers-agent (from
1fa147836736824c32a46889d6fb59402d4e58bd-14 to
9adc9d49378aa0a19b85d02c447b3eb1e2b87774-14):
     Jose Carlos Venegas Munoz - new agent version 9adc9d
          https://download.clearlinux.org/releases/18800/clear/RELEASENOTES

Fixes: #685

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>