### PR TITLE
Update versions: k8s and CRI-O

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -41,6 +41,7 @@ echo "Installing CRI-O"
 sudo -E PATH=$PATH sh -c "make clean"
 sudo -E PATH=$PATH sh -c "make install.tools"
 sudo -E PATH=$PATH sh -c "make"
+sudo -E PATH=$PATH sh -c "make test-binaries"
 sudo -E PATH=$PATH sh -c "make install"
 sudo -E PATH=$PATH sh -c "make install.config"
 

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -19,7 +19,7 @@ qemu_lite_sha=741f430a960b5b67745670e8270db91aeb083c5f-29
 go_version="1.8.3"
 
 #Kubernetes version compatible with Clear Containers
-kubernetes_version="1.7.8-00"
+kubernetes_version="1.8.3-00"
 
 # Openshift Origin version compatible with Clear Containers
 origin_version="v3.6.0"

--- a/test-versions.txt
+++ b/test-versions.txt
@@ -1,5 +1,5 @@
 # Well known working crio tag/commit/branch
-crio_version=v1.0.2
+crio_version=v1.0.4
 
 # Runc version compatible with crio_version
 runc_version=84a082bfef6f932de921437815355186db37aeb1


### PR DESCRIPTION
This PR contains 2 commits to update the releases of dependencies we use for testing:
- CRI-O to 1.0.4
- Kubernetes to 1.8.3