### PR TITLE
integration: docker: Fix diff test by making sure the container runs

### DIFF
--- a/integration/docker/diff_test.go
+++ b/integration/docker/diff_test.go
@@ -28,7 +28,9 @@ var _ = Describe("diff", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		_, _, exitCode := DockerRun("--name", id, "-d", Image, "sh")
+		// Run this command with -i flag to make sure we keep the
+		// container up and running.
+		_, _, exitCode := DockerRun("--name", id, "-d", "-i", Image, "sh")
 		Expect(exitCode).To(Equal(0))
 		_, _, exitCode = DockerExec(id, "mkdir", name)
 		Expect(exitCode).To(Equal(0))


### PR DESCRIPTION
    integration: docker: Fix diff test by making sure the container runs
    
    The diff test needs to use -i flag in order to keep the container
    process running while a "docker exec" is started. This issue was
    not visible before because STDIN was never closed on the agent side,
    even if it was on the host side. With recent patch from the agent,
    this issue got highlighted.
    
    Fixes #705
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>