### PR TITLE
versions: Update Clear Containers image

### DIFF
--- a/test-versions.txt
+++ b/test-versions.txt
@@ -5,7 +5,7 @@ crio_version=v1.0.2
 runc_version=84a082bfef6f932de921437815355186db37aeb1
 
 # Clear Containers image version
-image_version=18860
+image_version=19070
 
 # Kernel Version to use on recent Linux Distros
 kernel_clear_release=18670


### PR DESCRIPTION
- version: 18800
  - Changes in package clear-containers-agent (from
  1fa147836736824c32a46889d6fb59402d4e58bd-14 to
  9adc9d49378aa0a19b85d02c447b3eb1e2b87774-14):
    - Jose Carlos Venegas Munoz - new agent version 9adc9d

  https://download.clearlinux.org/releases/18800/clear/RELEASENOTES

- version: 19010
    - Changes in package systemd (from 234-153 to 234-154):
    Miguel Bernal Marin - version bump from 234-153 to 234-154
    Victor Rodriguez - Fix CVE-2017-15908

  https://download.clearlinux.org/releases/19010/clear/RELEASENOTES

  version: 19050
  - Changes in package systemd (from 234-154 to 234-157):
    - Arjan van de Ven - don't do transient hostnames; we set ours already
    - Arjan van de Ven - move vconsole to the console subpackage

  https://download.clearlinux.org/releases/19050/clear/RELEASENOTES

- version: 19060
  - Changes in package clear-containers-agent (from 9adc9d49378aa0a19b85d02c447b3eb1e2b87774-14 to
  243e2aefa4f9ff5a1bd32967a213e8533dab54df-15):
    - Jose Carlos Venegas Munoz - version bump from 243e2aefa4f9ff5a1bd32967a213e8533dab54df-14 to
      243e2aefa4f9ff5a1bd32967a213e8533dab54df-15
     Jose Carlos Venegas Munoz - New agent version 243e2ae

  - Changes in package systemd (from 234-154 to 234-157):
    -Arjan van de Ven - don't do transient hostnames;
      we set ours already Arjan van de Ven - move vconsole to the console subpackage

  https://download.clearlinux.org/releases/19060/clear/RELEASENOTES

Fixes: #708

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>