### PR TITLE
CI: metrics: Jenkins: Do not run QA checks for metrics CI

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -72,8 +72,15 @@ fi
 # components
 .ci/setup.sh
 
-# Run the test suite
-.ci/run.sh
+# The metrics CI does not need to do the QA checks - it only runs once
+# it knows the QA CI has passed already.
+if [ -z "${METRICS_CI}" ]
+then
+	# Run the test suite
+	.ci/run.sh
+else
+	echo "Under METRICS_CI - skipping test run"
+fi
 
 # Publish the code coverage if needed.
 if [ ${COVERALLS_REPO_TOKEN} ]


### PR DESCRIPTION
When we are running the metrics CI we presume (or have checked)
that the QA tests already work. We do not need to run them again
before we run the metrics CI.
Thus, only run the QA checks when we are not under the METRICS_CI.

Fixes: #710

Signed-off-by: Graham Whaley <graham.whaley@intel.com>