### PR TITLE
functional: Fix exec tests

### DIFF
--- a/container.go
+++ b/container.go
@@ -88,21 +88,21 @@ func (c *Container) Run() (string, string, int) {
 	args := []string{}
 
 	if c.LogFile != nil {
-		args = append(args, "--log", *c.LogFile)
+		args = append(args, fmt.Sprintf("--log=%s", *c.LogFile))
 	}
 
 	args = append(args, "run")
 
 	if c.Bundle != nil {
-		args = append(args, "--bundle", c.Bundle.Path)
+		args = append(args, fmt.Sprintf("--bundle=%s", c.Bundle.Path))
 	}
 
 	if c.Console != nil {
-		args = append(args, "--console", *c.Console)
+		args = append(args, fmt.Sprintf("--console=%s", *c.Console))
 	}
 
 	if c.PidFile != nil {
-		args = append(args, "--pid-file", *c.PidFile)
+		args = append(args, fmt.Sprintf("--pid-file=%s", *c.PidFile))
 	}
 
 	if c.Detach {
@@ -167,17 +167,17 @@ func (c *Container) Exec(process Process) (string, string, int) {
 	args := []string{}
 
 	if c.LogFile != nil {
-		args = append(args, "--log", *c.LogFile)
+		args = append(args, fmt.Sprintf("--log=%s", *c.LogFile))
 	}
 
 	args = append(args, "exec")
 
 	if process.Console != nil {
-		args = append(args, "--console", *process.Console)
+		args = append(args, fmt.Sprintf("--console=%s", *process.Console))
 	}
 
 	if process.Tty != nil {
-		args = append(args, "--tty", *process.Tty)
+		args = append(args, fmt.Sprintf("--tty=%s", *process.Tty))
 	}
 
 	if process.Detach {
@@ -201,7 +201,7 @@ func (c *Container) List(format string, quiet bool, all bool) (string, string, i
 	args := []string{"list"}
 
 	if format != "" {
-		args = append(args, "--format", format)
+		args = append(args, fmt.Sprintf("--format=%s", format))
 	}
 
 	if quiet {

--- a/functional/exec_test.go
+++ b/functional/exec_test.go
@@ -43,16 +43,13 @@ func execDetachTiming(detach bool) TableEntry {
 }
 
 func execDetachOutput(detach bool) TableEntry {
-	output := "HelloWorld"
+	expectedOutput := "HelloWorld"
 
+	tty := "false"
 	process := Process{
-		Workload: []string{"echo", output},
+		Workload: []string{"echo", expectedOutput},
 		Detach:   detach,
-	}
-
-	expectedOutput := output
-	if detach {
-		expectedOutput = ""
+		Tty:      &tty,
 	}
 
 	return Entry(fmt.Sprintf("check output as detach=%t", detach), process, expectedOutput)


### PR DESCRIPTION
    functional: Fix exec tests
    
    The functional tests enable terminal=true for exec commands, and at
    the same time, they use the old flag --console= without specifying
    any path. This leads STDIN to be closed when the command is executed,
    and the shim sends this info to the agent, which closes the terminal.
    This case should not be testable/acceptable since no terminal is
    configured and passed as an argument to the runtime, so that we can
    actually use terminal=true for the agent.
    
    This patch forces the use of terminal=false, meaning that STDOUT and
    STDERR will still be open to receive the output and it won't cause an
    error on the agent.
    
    Fixes #718
    
    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>