### PR TITLE
metrics: storage: remove the images after test

### DIFF
--- a/metrics/storage/fio_job.sh
+++ b/metrics/storage/fio_job.sh
@@ -164,7 +164,7 @@ function main()
 	create_fio_job
 
 	# Launch container
-	output=$(docker run --runtime="$RUNTIME" \
+	output=$(docker run --rm --runtime="$RUNTIME" \
 		"$FIO_IMAGE" bash -c "$FIO_JOB")
 
 	# Parse results


### PR DESCRIPTION
Remove the storage images from docker (with --rm) once they have
finished. In particular, these images create large (4G) files when
testing, so consume a lot of space if they are just left around.

Fixes: #726

Signed-off-by: Graham whaley <graham.whaley@intel.com>