### PR TITLE
metrics: Add remote networking RSS memory measurement

### DIFF
--- a/metrics/network/remote_network/README.md
+++ b/metrics/network/remote_network/README.md
@@ -4,26 +4,30 @@
 `iperf3`using a remote setup. Host A will run a container that will act as a server while host B will run a
 container that will act as a client. The network bandwidth will be measured across the containers.
 
+- The `remote-networking-memory-smem.sh` script measures RSS memory with `smem` tool. Simultaneously,
+the script uses a remote setup to run a bandwidth network test.
+
 ## Prerequisite
 
 An automatic login from host A (user A) to host B (user B) is needed. You must setup authentication 
 keys to do an ssh login without password.
-The `remote-networking-iperf3.sh` is only compatible with `docker 1.12.1`.
+The `remote-networking-iperf3.sh` and `remote-networking-memory-smem.sh` scripts are only compatible with
+`docker 1.12.1`.
 
-## Running the remote networking test
+## Running the `remote-networking-iperf3.sh` test
 
 `remote-networking-iperf3.sh` should run in host A. The script needs the following inputs to run:
 - Arguments of the test to run. In this case the arguments are `-b` for bandwidth, `-j` for jitter,
 `-l` for latency, `-p` for parallel bandwidth and `-t` to run all the tests.
-- Interface name where swarm will run.
-- User of the host B.
-- IP address of the host B.
+- Use `-i` to specify the name of the interface where the swarm will run.
+- Use `-u` to specify the username of host B.
+- Use `-a` to specify the IP address of host B.
 
-The `remote-networking-iperf3.sh` test may be run manually:
+Use the following commands to run the `remote-networking-iperf3.sh` test manually:
 
 ```
 $ cd metrics/network/remote_network
-$ bash remote-networking-iperf3.sh "[options]" "<interface_name>" "<user>" "<ip_address>"
+$ bash remote-networking-iperf3.sh "[options]" -i "<interface_name>" -u "<user>" -a "<ip_address>"
 
 ```
 
@@ -32,5 +36,21 @@ This is an example of how to run this script:
 ```
 $ cd metrics/network/remote_network
 $ bash remote-networking-iperf3.sh -b -i eno1 -u tester -a 10.xxx.xxx.xxx
+
+```
+
+## Running the `remote-networking-memory-smem.sh` test
+
+`remote-networking-memory-smem.sh` script should run in host A. The script needs the following inputs to run:
+- Arguments of the test to run. In this case the argument is `-r` for RSS memory. Use `-r` option for RSS memory.
+- Use `-i` to specify the name of the interface where the swarm will run.
+- Use `-u` to specify the username of host B.
+- Use `-a` to specify the IP address of host B.
+
+Use the following commands to run the `remote-networking-memory-smem.sh` test manually:
+
+```
+$ cd metrics/network/remote_network
+$ bash remote-networking-memory-smem.sh "[options]" -i "<interface_name>" -u "<user>" -a "<ip_address>"
 
 ```

--- a/metrics/network/remote_network/remote-networking-memory-smem.sh
+++ b/metrics/network/remote_network/remote-networking-memory-smem.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script will measure RSS memory with smem tool while running an iperf3
+# bandwidth network measurement using a remote setup, where host A will run a
+# server container and host B will run a client container.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/remote-networking-test-common.sh"
+
+# Set QEMU_PATH unless it's already set
+QEMU_PATH=${QEMU_PATH:-$(get_qemu_path)}
+# Time in which we sample the memory (seconds)
+middle_time=10
+# Time to run the server using iperf3 (seconds)
+server_time=30
+
+# This function describes how to use this script
+function help {
+echo "$(cat << EOF
+Usage: $0 "[options]"
+	Description:
+		This script measures RSS memory using smem tool. Simultaneously, the script
+		runs a server container and host B runs a client container.
+		To run this script, provide the following inputs:
+		- Interface name where swarm will run.
+		- User of the host B.
+		- IP address of the host B
+	Options:
+		-h      Shows help
+		-r      Run RSS memory
+		-i      Interface name to run Swarm (mandatory)
+		-u      User of host B (mandatory)
+		-a      IP address of host B (mandatory)
+
+EOF
+)"
+}
+
+# This function will measure the bandwidth using iperf3
+function remote_network_rss_memory {
+	test_name="Remote Network RSS Memory"
+	units="Kb"
+	setup_swarm
+	client_replica_status
+	server_replica_status
+
+	server_ip_address=$(check_server_address)
+	start_server
+
+	client_id=$($DOCKER_EXE ps -q)
+	client_command="mount -t ramfs -o size=20M ramfs /tmp && \
+			iperf3 -c $server_ip_address -t $server_time"
+	start_client "$client_id" "$client_command" > /dev/null
+
+	# Time when we are taking our RSS measurement
+	echo >&2 "WARNING: Sleeping for $middle_time seconds to sample the RSS memory"
+	sleep ${middle_time}
+
+	process="$QEMU_PATH"
+	memory_command="sudo smem --no-header -c rss"
+	result=$(${memory_command} -P ^${process})
+
+	memory=$(echo "$result" | awk '{ total += $1 } END { print total/NR }')
+	echo "RSS Memory is : $memory $units"
+	save_results "$test_name" "RSS memory" "$memory" "$units"
+
+	clean_environment
+}
+
+function main {
+	local OPTIND
+	while getopts "hr:i:u:a" opt
+	do
+		case "${opt}" in
+		h)
+			help
+			exit 0;
+		;;
+		r)
+			rss_memory_test="1"
+			remote_network_rss_memory
+		;;
+		i)
+			interface_name="${OPTARG}"
+		;;
+		u)
+			ssh_user="${OPTARG}"
+		;;
+		a)
+			ssh_address="${OPTARG}"
+		;;
+		esac
+		shift
+	done
+	shift $((OPTIND-1))
+
+	[ -z "$ssh_address" ] && help && die "Mandatory IP address of host B not supplied."
+	[ -z "$ssh_user" ] && help && die "Mandatory user of host B not supplied."
+	[ -z "$interface_name" ] && help && die "Mandatory interface name to run Swarm not supplied."
+
+}
+main "$@"

--- a/metrics/network/remote_network/remote-networking-test-common.sh
+++ b/metrics/network/remote_network/remote-networking-test-common.sh
@@ -20,6 +20,7 @@
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../lib/common.bash"
+LIB_DIR="${SCRIPT_PATH}/../../lib"
 
 # Argument of the test to run
 argument="$1"


### PR DESCRIPTION
This test will measure RSS memory using smem tool while
running a bandwidth remote network measurement with iperf3.

Fixes #739

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>