### PR TITLE
ci: jenkins: add /sbin to the PATH

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -36,7 +36,7 @@ mkdir -p ${GOPATH}
 
 # Export all environment variables needed.
 export GOROOT="/usr/local/go"
-export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:${PATH}
+export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:/sbin:${PATH}
 
 # We need to set CI in order to enable proper coverage tool operation
 export CI=true


### PR DESCRIPTION
cc-runtime cc-check started failing for me - it looks like
if we are not a priv'd user then we need /sbin in our PATH
to find modprobe, or we fail the checks (for vhost enabled
for instance).
Add /sbin to our existing PATH manipulation.

Fixes: #741

Signed-off-by: Graham whaley <graham.whaley@intel.com>