### PR TITLE
ci: Do not use sudo when building cri-o

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -38,10 +38,10 @@ sudo install "${GOPATH}/bin/crictl" /usr/bin
 popd
 
 echo "Installing CRI-O"
-sudo -E PATH=$PATH sh -c "make clean"
-sudo -E PATH=$PATH sh -c "make install.tools"
-sudo -E PATH=$PATH sh -c "make"
-sudo -E PATH=$PATH sh -c "make test-binaries"
+make clean
+make install.tools
+make
+make test-binaries
 sudo -E PATH=$PATH sh -c "make install"
 sudo -E PATH=$PATH sh -c "make install.config"
 


### PR DESCRIPTION
We don't need sudo to build cri-o and this leads to having files
owned by root, which is an issue when trying to clean up the
environment.

Fixes: #745.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>