### PR TITLE
metrics: Improve warn and killing of unexpected processes

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -32,6 +32,14 @@ die(){
 	exit 1
 }
 
+# Sometimes we just want to warn about something - let's have a standard
+# method for that, so maybe we can make a standard form that can be searched
+# for in the logs/tooling
+warning(){
+	msg="$*"
+	echo "WARNING: $msg" >&2
+}
+
 # Save a test/metric result.
 # This is a wrapper function to the send_results.sh command, which ultimately decides
 # where and in what format to store or process the data.


### PR DESCRIPTION
We were silently killing stray hypervisors and shim processes, but we were not doing that with `sudo`, so sometimes we would get stray `process not found`errors whilst running the metrics.
Make it now a more blatant warning with some process details, and do the killall with sudo.

It is debatable if we should warn or die here - having stray processes hanging around might be a strong indicator of a bug...