### PR TITLE
metrics: Add save_results and baremetal support to remote tests

### DIFF
--- a/metrics/network/remote_network/remote-networking-test-common.sh
+++ b/metrics/network/remote_network/remote-networking-test-common.sh
@@ -22,14 +22,6 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../lib/common.bash"
 LIB_DIR="${SCRIPT_PATH}/../../lib"
 
-# Argument of the test to run
-argument="$1"
-# Name of the interface were swarm will run
-interface_name="$3"
-# Name of the user (ssh)
-ssh_user="$5"
-# Ip address (ssh)
-ssh_address="$7"
 # Image for network testing
 network_image="gabyct/network"
 # Number of replicas that will be launch in each host
@@ -44,6 +36,28 @@ second_service="testswarm2"
 port_first_service="8080:80"
 # Port where the second service will run
 port_second_service="8081:80"
+# Mount command for iperf3 (cc-runtime)
+mount="mount -t ramfs -o size=20M ramfs /tmp"
+
+# This function will retrieve the runtime from
+# host A and host B
+function get_runtime {
+	# Check runtime of host A
+	runtime_client=$($DOCKER_EXE info 2>/dev/null | grep "Default Runtime" | cut -f2 -d':' | tr -d "[:space:]")
+	if [ "$runtime_client" == "runc" ]; then
+		client_extra_args="--privileged"
+	fi
+	# Check runtime of host B
+	runtime_server=$(ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
+		$DOCKER_EXE info 2>/dev/null | grep "Default Runtime" | cut -f2 -d':' | tr -d "[:space:]"')
+	if [ "$runtime_server" == "runc" ]; then
+		server_extra_args="--privileged"
+	fi
+	# Check both hosts have the same runtime
+	if [ "$runtime_client" != "$runtime_server" ]; then
+		die "Client runtime: '$runtime_client' is not equal to Server runtime: '$runtime_server'."
+	fi
+}
 
 # This function will start swarm as well as it will label
 # the nodes and create the replicas
@@ -59,11 +73,11 @@ function setup_swarm {
 	$DOCKER_EXE service create \
 		--name "$first_service" --replicas "$number_of_replicas" \
 		--constraint 'node.labels.machine == machine1' \
-		--publish "$port_first_service" "$network_image" sh
+		--publish "$port_first_service" "$network_image" tail -f /dev/null
 	$DOCKER_EXE service create \
 		--name "second_service" --replicas "$number_of_replicas" \
 		--constraint 'node.labels.machine == machine2' \
-		--publish "$port_second_service" "$network_image" sh
+		--publish "$port_second_service" "$network_image" tail -f /dev/null
 }
 
 # This function will verify that the replica on the host client is running
@@ -99,17 +113,42 @@ function check_server_address {
 
 # This function will start an iperf3 server
 function start_server {
-	ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
+	get_runtime
+	if [ "$runtime_server" == "runc" ]; then
+		ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
 			server_id=$($DOCKER_EXE ps -q); \
-			server_command="mount -t ramfs -o size=20M ramfs /tmp && iperf3 -s"; \
+			server_command="iperf3 -s"; \
 			$DOCKER_EXE exec -d "$server_id" sh -c "$server_command"'
+	elif [ "$runtime_server" == "cc-runtime" ]; then
+		ssh "$ssh_user"@"$ssh_address" 'DOCKER_EXE=docker; \
+			server_id=$($DOCKER_EXE ps -q); \
+			mount="mount -t ramfs -o size=20M ramfs /tmp"; \
+			server_command="$mount && iperf3 -s"; \
+			$DOCKER_EXE exec -d "$server_id" sh -c "$server_command"'
+	else
+		die "Unknown server runtime: $runtime_server."
+	fi
+}
+
+# This function will check client command for iperf3
+function check_iperf3_client_command {
+	get_runtime
+	command="$1"
+	if [ "$runtime_client" == "runc" ]; then
+		client_command="$command"
+	elif [ "$runtime_client" == "cc-runtime" ]; then
+		client_command="$mount && $command"
+	else
+		die "Unknown client runtime: $runtime_client."
+	fi
 }
 
 # This function will start an iperf3 client
 function start_client {
-	client_id="$1"
-	client_command="$2"
-	$DOCKER_EXE exec "$client_id" sh -c "$client_command"
+	extra_args="$1"
+	client_id="$2"
+	client_command="$3"
+	$DOCKER_EXE exec "$extra_args" "$client_id" sh -c "$client_command"
 }
 
 # This function will remove swarm on both client and server hosts


### PR DESCRIPTION
Add the functionality of save_results as well as support runc
in the remote networking tests.

Fixes #754

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>