### PR TITLE
metrics: killall: do not use the binary path in killall

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -3,6 +3,20 @@
 This section contains a collection of scripts designed to measure the performance
 and responsiveness of the different components which form Clear Containers.
 
+> **WARNING**
+>
+> Running the metrics tests might modify your existing setup or containers.
+>
+> During initialization, the metrics tests code tries to bring the system into a
+> known stable state before the tests are executed. This action involves removing
+> and killing off any running containers, any parts of the Clear Containers
+> runtime system that might have been left running from any previous executions,
+> and resetting some sub-parts of the container subystems (e.g. docker) through
+> `systemctl` et. al.
+>
+> We recommended you do not run the metrics tests on a "live" system
+> that has active containers you do not want to kill.
+
 ## Metrics tests - content
 
 The tests are organized in the following sections:

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -270,14 +270,14 @@ function kill_processes_before_start() {
 		# Sometimes we race and the process has gone by the time we list
 		# it - so make a pgrep fail non-fatal
 		pgrep -a -f "$HYPERVISOR_PATH" || true
-		sudo killall -9 "$HYPERVISOR_PATH" || true
+		sudo killall -9 "${HYPERVISOR_PATH##*/}" || true
 	fi
 
 	result=$(check_active_process "$CC_SHIM_PATH")
 	if [[ $result -ne 0 ]]; then
 		warning "Found unexpected ${CC_SHIM_PATH} processes present"
 		pgrep -a -f "$CC_SHIM_PATH" || true
-		sudo killall -9 "$CC_SHIM_PATH" || true
+		sudo killall -9 "${CC_SHIM_PATH##*/}" || true
 	fi
 }
 


### PR DESCRIPTION
If you have any path characters in the argument to killall
then it will only kill the processes actually using that
binary. Thus, if you have any stuck processes that are using
a different (or previous that has since been replaced) binary,
killall will not find/kill them.
Change the killall to use just the process/file name (with no
path), which means it will kill all processes of that name
(even if they were launched from a binary in a different path)
which may feel a little more 'dangerous', but as we only run
this in reasonably well defined and constrained systems, it
should be fine.

Fixes: #757

Signed-off-by: Graham whaley <graham.whaley@intel.com>