### PR TITLE
versions: Update image to version 19350

### DIFF
--- a/test-versions.txt
+++ b/test-versions.txt
@@ -5,7 +5,7 @@ crio_version=v1.0.4
 runc_version=84a082bfef6f932de921437815355186db37aeb1
 
 # Clear Containers image version
-image_version=19070
+image_version=19350
 
 # Kernel Version to use on recent Linux Distros
 kernel_clear_release=18670


### PR DESCRIPTION
Allows test for https://github.com/clearcontainers/runtime/pull/835

Fixes: #760

Changes:

version: 19170
Changes in package clear-containers-agent (from 243e2aefa4f9ff5a1bd32967a213e8533dab54df-15 to 04fa18641b046dbcf10d13dcd0715e288bff41ce-16):
     Jose Carlos Venegas Munoz - version bump from 04fa18641b046dbcf10d13dcd0715e288bff41ce-15 to 04fa18641b046dbcf10d13dcd0715e288bff41ce-16
     Jose Carlos Venegas Munoz - agent: New agent version 04fa18
https://download.clearlinux.org/releases/19170/clear/RELEASENOTES
version: 19180
Changes in package iptables (from 1.6.1-21 to 1.6.1-22):
     Arjan van de Ven - version bump from 1.6.1-21 to 1.6.1-22
https://download.clearlinux.org/releases/19180/clear/RELEASENOTES
version: 19200
Changes in package systemd (from 234-157 to 234-158):
     Arjan van de Ven - ship btrfs rule
https://download.clearlinux.org/releases/19200/clear/RELEASENOTES
version: 19340
Changes in package clear-containers-agent (from 04fa18641b046dbcf10d13dcd0715e288bff41ce-16 to b1d92e2aa14d915680e8fe770745a511857ac7ff-17):
     Jose Carlos Venegas Munoz - version bump from b1d92e2aa14d915680e8fe770745a511857ac7ff-16 to b1d92e2aa14d915680e8fe770745a511857ac7ff-17
     Jose Carlos Venegas Munoz - New agent version: b1d92e2
https://download.clearlinux.org/releases/19340/clear/RELEASENOTES
version: 19350
Changes in package clear-containers-agent (from 04fa18641b046dbcf10d13dcd0715e288bff41ce-16 to b1d92e2aa14d915680e8fe770745a511857ac7ff-17):
     Jose Carlos Venegas Munoz - version bump from b1d92e2aa14d915680e8fe770745a511857ac7ff-16 to b1d92e2aa14d915680e8fe770745a511857ac7ff-17
     Jose Carlos Venegas Munoz - New agent version: b1d92e2
https://download.clearlinux.org/releases/19350/clear/RELEASENOTES

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>