### PR TITLE
Fix metrics tests for headless operation

### DIFF
--- a/metrics/network/network-latency.sh
+++ b/metrics/network/network-latency.sh
@@ -40,7 +40,7 @@ function latency() {
 	# Initialize/clean environment
 	init_env
 
-	local server_command="sh"
+	local server_command="tail -f /dev/null"
 	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")
 
 	# Verify server IP address

--- a/metrics/network/network-metrics-nuttcp.sh
+++ b/metrics/network/network-metrics-nuttcp.sh
@@ -45,7 +45,7 @@ function udp_bandwidth() {
 	# Initialize/clean environment
 	init_env
 
-	local server_command="sh"
+	local server_command="tail -f /dev/null"
 	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")
 
 	local client_command="/root/nuttcp -T${transmit_timeout} -u -Ru -i1 -l${bl} ${server_address}"

--- a/metrics/storage/fio_job.sh
+++ b/metrics/storage/fio_job.sh
@@ -206,10 +206,10 @@ function main()
 	fi
 
 	# First we set up the container
-	CONTAINER_ID=$(docker run -tid --runtime="$RUNTIME" "$FIO_IMAGE" bash)
+	CONTAINER_ID=$(docker run -tid --runtime="$RUNTIME" "$FIO_IMAGE" tail -f /dev/null)
 
 	# Now we run the prep task
-	docker exec -ti ${CONTAINER_ID} bash -c "$FIO_PREP_JOB"
+	docker exec ${CONTAINER_ID} bash -c "$FIO_PREP_JOB"
 
 	# Kick off background tasks to measure the CPU, PSS and RSS
 	cpu_temp=$(mktemp fio_job_cpu.XXX)


### PR DESCRIPTION
A number of the metrics tests do not work under headless (such as some CI systems or running under `nohup`) systems.
Fix up a number of the tests to work (predominantly by not using `-ti` on docker run or trying to use long-running 'shell's to keep a container 'open' (switch to using `tail -f /dev/null`).