### PR TITLE
metrics: update/refresh docker images before running tests

### DIFF
--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -198,5 +198,6 @@ check_for_ksm
 init_env
 
 check_cmds "${SMEM_BIN}" bc
+check_images "$IMAGE"
 
 get_docker_memory_usage

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -109,6 +109,7 @@ function dump_caches() {
 
 function init() {
 	check_cmds $REQUIRED_COMMANDS
+	check_images "$PAYLOAD"
 	# Use the common init func to get to a known state
 	init_env
 

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -73,6 +73,29 @@ function check_cmds()
 	done
 }
 
+# This function performs a docker pull on the image names
+# passed in (notionally as 'about to be used'), to ensure
+#  - that we have the most upto date images
+#  - that any pull/refresh time (for a first pull) does not
+#    happen during the test itself.
+#
+# The image list can be received standalone or as an array, e.g.
+#
+# images=(“img1” “img2”)
+# check_imgs "${images[@]}"
+function check_images()
+{
+	local img req_images=( "$@" )
+	for img in "${req_images[@]}"; do
+		echo "docker pull'ing: $img"
+		if ! docker pull "$img"; then
+			die "Failed to docker pull image $img"
+			exit 1;
+		fi
+		echo "docker pull'd: $img"
+	done
+}
+
 # A one time (per uber test cycle) init that tries to get the
 # system to a 'known state' as much as possible
 function onetime_init()

--- a/metrics/network/network-latency.sh
+++ b/metrics/network/network-latency.sh
@@ -39,6 +39,7 @@ function latency() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	local server_command="tail -f /dev/null"
 	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")

--- a/metrics/network/network-metrics-cpu-consumption.sh
+++ b/metrics/network/network-metrics-cpu-consumption.sh
@@ -57,6 +57,7 @@ function cpu_consumption() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	local server_command="iperf -p ${port} -s"
 	local server_address=$(start_server "$image" "$server_command")

--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -297,6 +297,8 @@ echo "Currently this script is using ramfs for tmp (see https://github.com/01org
 
 init_env
 
+check_images "$image"
+
 iperf3_bandwidth
 
 iperf3_jitter

--- a/metrics/network/network-metrics-memory-pss-1g.sh
+++ b/metrics/network/network-metrics-memory-pss-1g.sh
@@ -56,6 +56,7 @@ function pss_memory() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	local server_command="sh"
 	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")

--- a/metrics/network/network-metrics-memory-pss.sh
+++ b/metrics/network/network-metrics-memory-pss.sh
@@ -51,6 +51,7 @@ function pss_memory() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	local server_command="iperf -p ${port} -s"
 	local server_address=$(start_server "$image" "$server_command")

--- a/metrics/network/network-metrics-memory-rss-1g.sh
+++ b/metrics/network/network-metrics-memory-rss-1g.sh
@@ -57,6 +57,7 @@ function rss_memory() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	local server_command="sh"
 	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")

--- a/metrics/network/network-metrics-nuttcp.sh
+++ b/metrics/network/network-metrics-nuttcp.sh
@@ -44,6 +44,7 @@ function udp_bandwidth() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	local server_command="tail -f /dev/null"
 	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")

--- a/metrics/network/network-metrics.sh
+++ b/metrics/network/network-metrics.sh
@@ -42,6 +42,7 @@ function bidirectional_bandwidth_server_client() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	server_command="iperf -p ${port} -s"
 	local server_address=$(start_server "$image" "$server_command")

--- a/metrics/network/network-nginx-ab-benchmark.sh
+++ b/metrics/network/network-nginx-ab-benchmark.sh
@@ -46,6 +46,7 @@ function nginx_ab_networking() {
 
 	# Initialize/clean environment
 	init_env
+	check_images "$image"
 
 	# Verify apache benchmark
 	cmds=("ab")

--- a/metrics/storage/fio_job.sh
+++ b/metrics/storage/fio_job.sh
@@ -192,6 +192,7 @@ function main()
 
 	init_env
 	check_cmds "${cmds[@]}"
+	check_images "$FIO_IMAGE"
 	create_fio_run_job
 	create_fio_prep_job
 

--- a/metrics/time/docker_workload_time.sh
+++ b/metrics/time/docker_workload_time.sh
@@ -35,13 +35,6 @@ TEST_NAME="docker run time"
 TEST_ARGS="image=${IMAGE} command=${CMD} runtime=${RUNTIME} units=seconds"
 TEST_RESULT_FILE=$(echo "${RESULT_DIR}/${TEST_NAME}-${IMAGE}-${CMD}-${RUNTIME}" | sed 's| |-|g')
 
-# Ensure we have yanked down the necessary images before we begin - we do not
-# want to be adding that overhead into any of our measurement times
-function prewarm(){
-	echo Pre-warming by pulling $IMAGE
-	docker pull $IMAGE
-}
-
 function run_workload(){
 	# temporarily unset 'e' as we want to carry on to report if this fails.
 	# but set it in the subshell, as we'd like the docker command to fail and bail , rather than
@@ -69,7 +62,7 @@ function run_workload(){
 }
 
 init_env
-prewarm
+check_images "$IMAGE"
 for i in $(seq 1 "$TIMES"); do
 	run_workload
 done

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -62,13 +62,6 @@ ns_to_s() {
 	echo $(bc <<< "scale=3; $1 / 1000000000")
 }
 
-# Ensure we have yanked down the necessary images before we begin - we do not
-# want to be adding that overhead into any of our measurement times
-prewarm() {
-	echo "Pre-warming by pulling $IMAGE"
-	docker pull $IMAGE
-}
-
 run_workload() {
 	start_time=$($DATECMD)
 
@@ -154,7 +147,7 @@ init () {
 
 	# Start from a fairly clean environment
 	init_env
-	prewarm
+	check_images "$IMAGE"
 }
 
 help() {


### PR DESCRIPTION
Most of the tests did not check to see if there was an update to the docker images they were using.
Fix this by adding a generic function to do the check, and invoke it from the tests.