### PR TITLE
ci: Update how journalctl gets the cc-proxy log

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -40,7 +40,7 @@ crio_log_prefix="crio_"
 if [ ${log_copy_dest} ]; then
 	# Create the log files
 	journalctl --no-pager -t cc-runtime > "${runtime_log_path}"
-	journalctl --no-pager -u cc-proxy > "${proxy_log_path}"
+	journalctl --no-pager -t cc-proxy > "${proxy_log_path}"
 	journalctl --no-pager -t cc-shim > "${shim_log_path}"
 	journalctl --no-pager -u crio > "${crio_log_path}"
 


### PR DESCRIPTION
Now that the cc-proxy will not be a service, we need to use
option -t in journalctl to get the logs from the proxy.
Relates to:
https://github.com/clearcontainers/runtime/pull/835
https://github.com/clearcontainers/proxy/pull/177

Fixes: #775

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>