### PR TITLE
pullapprove: Add documentation team for approval

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -53,6 +53,5 @@ groups:
           - "vendor/*"
           - "*/vendor/*"
     required: 1
-    users:
-      - iphutch
-      - rcaballeromx
+    teams:
+      - documentation


### PR DESCRIPTION
Instead of listing the users from the documentation team, add the
github documentation team for documentation approval.

Fixes #785.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>