### PR TITLE
metrics: common: do not fail if pgrep fails

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -270,14 +270,14 @@ function kill_processes_before_start() {
 		# Sometimes we race and the process has gone by the time we list
 		# it - so make a pgrep fail non-fatal
 		pgrep -a -f "$HYPERVISOR_PATH" || true
-		sudo killall "$HYPERVISOR_PATH" || true
+		sudo killall -9 "$HYPERVISOR_PATH" || true
 	fi
 
 	result=$(check_active_process "$CC_SHIM_PATH")
 	if [[ $result -ne 0 ]]; then
 		warning "Found unexpected ${CC_SHIM_PATH} processes present"
 		pgrep -a -f "$CC_SHIM_PATH" || true
-		sudo killall "$CC_SHIM_PATH" || true
+		sudo killall -9 "$CC_SHIM_PATH" || true
 	fi
 }
 

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -267,15 +267,17 @@ function kill_processes_before_start() {
 	result=$(check_active_process "$HYPERVISOR_PATH")
 	if [[ $result -ne 0 ]]; then
 		warning "Found unexpected ${HYPERVISOR_PATH} processes present"
-		pgrep -a -f "$HYPERVISOR_PATH"
-		sudo killall "$HYPERVISOR_PATH"
+		# Sometimes we race and the process has gone by the time we list
+		# it - so make a pgrep fail non-fatal
+		pgrep -a -f "$HYPERVISOR_PATH" || true
+		sudo killall "$HYPERVISOR_PATH" || true
 	fi
 
 	result=$(check_active_process "$CC_SHIM_PATH")
 	if [[ $result -ne 0 ]]; then
 		warning "Found unexpected ${CC_SHIM_PATH} processes present"
-		pgrep -a -f "$CC_SHIM_PATH"
-		sudo killall "$CC_SHIM_PATH"
+		pgrep -a -f "$CC_SHIM_PATH" || true
+		sudo killall "$CC_SHIM_PATH" || true
 	fi
 }
 


### PR DESCRIPTION
We use pgrep to report diagnostics on errant processes,
but sometimes those processes have gone by the time we
go looking for them. In that case pgrep fails, but is non
fatal.
Code it as so.

Fixes: #787

Signed-off-by: Graham whaley <graham.whaley@intel.com>