### PR TITLE
metrics: Fix typo in one of the iperf3 tests.

### DIFF
--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -269,7 +269,7 @@ function get_host_cnt_bwd() {
 # where the container take the server role and the iperf client lives
 # in the host.
 function iperf_host_cnt_bwd() {
-	local test_name="newtwork bwd host contr"
+	local test_name="network bwd host contr"
 	local result="$(get_host_cnt_bwd)"
 	parse_iperf_bwd "$test_name" "$result"
 }


### PR DESCRIPTION
Fix typo in the name of the iperf3 test.

Fixes #797

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>