### PR TITLE
ci: pull kernel from github release

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,46 @@
+# Continuous Integration scripts #
+
+This directory contains a set of files to run the Clear Containers CI
+test.
+
+The main files used by the CI are : 
+
+- `setup.sh`: Sets the needed environment to run Clear Containers tests
+
+- `run.sh`: Runs Clear Containers tests in this repository
+
+The Clear Containers CI uses the latest components from the Clear
+Containers project: runtime, proxy, and shim are built and installed from
+source. But the kernel, hypervisor, and Clear Containers image are
+pre-built and downloaded as binaries to reduce CI execution time.
+
+## Clear Containers Kernel for CI ##
+
+Each time the CI environment is configured, the kernel is downloaded from
+the [Clear Containers Linux fork release
+page](https://github.com/clearcontainers/linux/releases). 
+
+The Clear Containers Linux fork provides the kernel configuration and
+required patches for Clear Containers. The patches and configuration are
+tracked in the [Clear Containers packaging
+repository](https://github.com/clearcontainers/packaging/tree/master/kernel).
+When a new change is done in the packaging repository, the fork is updated
+and binaries are updated in a GitHub release. For more details about the
+update sequence, see [Kernel Update
+Sequence](https://github.com/clearcontainers/packaging/tree/master/kernel#update-sequence).
+
+The script `install_clearcontainers_kernel.sh` is used to install the
+latest kernel binaries.
+
+** Note: The script downloads the latest kernel each time the CI is
+configured, for Clear Containers users it is highly recommended to install
+the kernel from the Clear Containers packages (see [installation
+guide](https://github.com/clearcontainers/runtime/wiki/Installation)).
+
+Each time a new Clear Containers release is done, the 
+`clear_container_kernel` variable in the file
+[versions.txt](https://github.com/clearcontainers/runtime/blob/master/versions.txt)
+is updated to define the recommended kernel version to use for the Clear
+Containers release. For more details about the Clear Containers kernel
+update, see [assets
+update](https://github.com/clearcontainers/runtime/blob/master/docs/assets-update.md#clear-containers-kernel-update).**

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -20,8 +20,7 @@ cidir=$(dirname "$0")
 source /etc/os-release
 source "${cidir}/lib.sh"
 get_cc_versions
-
-cc_kernel_path="/usr/share/clear-containers"
+cc_image_path="/usr/share/clear-containers"
 
 if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
 	echo "enable Nested Virtualization"
@@ -43,10 +42,10 @@ echo "Install qemu-lite binary"
 "${cidir}/install_qemu_lite.sh" "${qemu_lite_clear_release}" "${qemu_lite_sha}" "$ID"
 
 echo "Install clear-containers image"
-"${cidir}/install_clear_image.sh" "$clear_vm_image_version" "${cc_kernel_path}"
+"${cidir}/install_clear_image.sh" "$clear_vm_image_version" "${cc_image_path}"
 
 echo "Install Clear Containers Kernel"
-"${cidir}/install_clear_kernel.sh" "${clear_kernel_release}" "${clear_container_kernel}" "${cc_kernel_path}"
+"${cidir}/install_clear_kernel.sh" "latest"
 
 echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel 	  \

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -45,7 +45,7 @@ echo "Install clear-containers image"
 "${cidir}/install_clear_image.sh" "$clear_vm_image_version" "${cc_image_path}"
 
 echo "Install Clear Containers Kernel"
-"${cidir}/install_clear_kernel.sh" "latest"
+"${cidir}/install_clearcontainers_kernel.sh" "latest"
 
 echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel 	  \

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -21,7 +21,7 @@ source "/etc/os-release"
 source "${cidir}/lib.sh"
 get_cc_versions
 
-cc_kernel_path="/usr/share/clear-containers"
+cc_image_path="/usr/share/clear-containers"
 
 if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
 	echo "enable Nested Virtualization"
@@ -42,7 +42,7 @@ echo "Install qemu-lite binary"
 "${cidir}/install_qemu_lite.sh" "${qemu_lite_clear_release}" "${qemu_lite_sha}" "$ID"
 
 echo "Install clear-containers image"
-"${cidir}/install_clear_image.sh" "$clear_vm_image_version" "${cc_kernel_path}"
+"${cidir}/install_clear_image.sh" "$clear_vm_image_version" "${cc_image_path}"
 
 echo "Install CRI-O dependencies for all Ubuntu versions"
 chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev
@@ -58,7 +58,7 @@ echo "Install Build Tools"
 sudo -E apt install -y build-essential python pkg-config zlib1g-dev
 
 echo "Install Clear Containers Kernel"
-"${cidir}/install_clear_kernel.sh" "${clear_kernel_release}" "${clear_container_kernel}" "${cc_kernel_path}"
+"${cidir}/install_clear_kernel.sh" "latest"
 
 echo -e "Install CRI-O dependencies available for Ubuntu $VERSION_ID"
 sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -58,7 +58,7 @@ echo "Install Build Tools"
 sudo -E apt install -y build-essential python pkg-config zlib1g-dev
 
 echo "Install Clear Containers Kernel"
-"${cidir}/install_clear_kernel.sh" "latest"
+"${cidir}/install_clearcontainers_kernel.sh" "latest"
 
 echo -e "Install CRI-O dependencies available for Ubuntu $VERSION_ID"
 sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux


### PR DESCRIPTION
Instead of pull kernel from Clear Linux rpm use our binaries uploaded to
github.

Fixes: #815

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>