### PR TITLE
checkmetrics: nobaseline: set precison of output table data

### DIFF
--- a/cmd/checkmetrics/main.go
+++ b/cmd/checkmetrics/main.go
@@ -158,11 +158,11 @@ func processMetrics(context *cli.Context) (err error) {
 		}
 
 		row := []string{thisCsv.TestName,
-			strconv.FormatFloat(thisCsv.Mean, 'f', -1, 64),
-			strconv.FormatFloat(thisCsv.MaxVal, 'f', -1, 64),
-			strconv.FormatFloat(thisCsv.MinVal, 'f', -1, 64),
-			strconv.FormatFloat(thisCsv.SD, 'f', -1, 64),
-			strconv.FormatFloat(thisCsv.CoV, 'f', -1, 64),
+			strconv.FormatFloat(thisCsv.Mean, 'f', 3, 64),
+			strconv.FormatFloat(thisCsv.MaxVal, 'f', 3, 64),
+			strconv.FormatFloat(thisCsv.MinVal, 'f', 3, 64),
+			strconv.FormatFloat(thisCsv.SD, 'f', 3, 64),
+			strconv.FormatFloat(thisCsv.CoV, 'f', 3, 64),
 			strconv.Itoa(thisCsv.Iterations)}
 
 		table.Append(row)


### PR DESCRIPTION
The output table data was being printed with 'infinite' precision,
which leads to a very noisy table (like 16+ digits of precision).
Let's make the table more readable (and more likely to fit on an
80 column screen) by setting precision to 3 - we really/rarely need
to see more than that.

Fixes: #824

Signed-off-by: Graham Whaley <graham.whaley@intel.com>