### PR TITLE
tests: Update swarm test to ensure not processes are left behind.

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -281,6 +281,18 @@ function kill_processes_before_start() {
 	fi
 }
 
+# This function checks if active processes were
+# left behind by cc-runtime.
+function check_processes() {
+	process=$1
+	pgrep -f "$process"
+	if [ $? -eq 0 ]; then
+		echo "Found unexpected ${process} present"
+		ps -ef | grep $process
+		return 1
+	fi
+}
+
 # Generate a random name - generally used when creating containers, but can
 # be used for any other appropriate purpose
 function random_name() {


### PR DESCRIPTION
This will ensure that we have a clean environment before running
swarm tests, also it will ensure to select an interface for
running swarm and finally it will ensure that not processes are
left behind after running swarm test.

Fixes #830

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>