### PR TITLE
test:Change test order until swarm + openshift issue is fixed.

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -16,6 +16,21 @@
 
 set -e
 source /etc/os-release
+start_test="$(date '+%Y-%m-%d %H:%M:%S')"
+last_test="${start_test}"
+
+function cleanup {
+	if (( "$?" != 0 )); then
+		echo "DEBUG: Logs from all test "
+		sudo journalctl -t cc-runtime  --since="${start_test}" --no-pager
+		if [ "${start_test}" != "${last_test}" ]; then
+			echo "DEBUG: Logs from last test"
+			sudo journalctl -t cc-runtime  --since="${last_test}" --no-pager
+		fi
+	fi
+}
+
+trap cleanup EXIT
 
 if [ "$ID" == "ubuntu" ] && [ "$VERSION_ID" == "17.04" ]; then
 	export CRIO_STORAGE_DRIVER_OPTS="--storage-driver=devicemapper"
@@ -26,5 +41,11 @@ sudo -E PATH="$PATH" bash -c "make check"
 # Currently, Openshift tests only work on Fedora.
 # We should delete this condition, when it works for Ubuntu.
 if [ "$ID" == fedora  ]; then
+	last_test=$(date '+%Y-%m-%d %H:%M:%S')
 	sudo -E PATH="$PATH" bash -c "make openshift"
 fi
+
+#FIXME: Running swarm before openshift breaks cc-runtime list
+# see https://github.com/clearcontainers/runtime/issues/902
+last_test=$(date '+%Y-%m-%d %H:%M:%S')
+sudo -E PATH="$PATH" bash -c "make swarm"

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ swarm:
 conformance:
 	bats conformance/posixfs/fstest.bats
 
-check: functional crio integration swarm conformance
+check: functional crio integration conformance
 
 all: functional checkcommits integration
 


### PR DESCRIPTION
Debug why cc-runtime is now woking after swarm test we need to keep checking our PRs move the order of the tests.

Because sometimes an issue can only be reproduced in CI add a function to show cc-runtime logs on error.

Fixes: #835