### PR TITLE
ci: Enable docker for default user

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -155,6 +155,9 @@ install_docker(){
 		die "Unrecognized tag. Tag supported is: swarm"
 	fi
 	sudo systemctl restart docker
+	sudo gpasswd -a ${USER} docker
+	sudo chmod g+rw /var/run/docker.sock
+	newgrp docker
 }
 
 # This function removes the installed docker package.


### PR DESCRIPTION
runtime unit tests require docker to be accessible by the
default user.

Fixes #848.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>