### PR TITLE
checkmetrics: print out 'acceptance range' info

### DIFF
--- a/cmd/checkmetrics/basefile.go
+++ b/cmd/checkmetrics/basefile.go
@@ -49,5 +49,15 @@ func newBasefile(file string) (*baseFile, error) {
 		log.Warningf("No entries found in basefile [%s]\n", file)
 	}
 
+	// Now calculate the % 'acceptance gap' for all the metrics so we can
+	// place it in the results table later on.
+	for n, m := range basefile.Metric {
+		basefile.Metric[n].Gap = ((m.MaxVal / m.MinVal) * 100.0) - 100
+		fmt.Printf(" Max %f, Min %f, Gap %f\n",
+			m.MaxVal,
+			m.MinVal,
+			m.Gap)
+	}
+
 	return &basefile, nil
 }

--- a/cmd/checkmetrics/compare.go
+++ b/cmd/checkmetrics/compare.go
@@ -35,6 +35,7 @@ func (mc *metricsCheck) reportTitleSlice() []string {
 		"Mean",
 		// This is the check boundary, not the largest value in Results
 		"Ceiling",
+		"Gap",
 		"Iters",
 		"SD",
 		"CoV"}
@@ -48,6 +49,7 @@ func (mc *metricsCheck) genSummaryLine(
 	minval string,
 	mean string,
 	maxval string,
+	gap string,
 	iterations string,
 	sd string,
 	cov string) (summary []string) {
@@ -63,6 +65,7 @@ func (mc *metricsCheck) genSummaryLine(
 		minval,
 		mean,
 		maxval,
+		gap,
 		iterations,
 		sd,
 		cov)
@@ -81,7 +84,7 @@ func (mc *metricsCheck) genErrorLine(
 	error3 string) (summary []string) {
 
 	summary = mc.genSummaryLine(passed, error1, error2, error3,
-		"", "", "", "")
+		"", "", "", "", "")
 	return
 }
 
@@ -131,6 +134,7 @@ func (mc *metricsCheck) check(m metrics, c csvRecord) (summary []string, err err
 		strconv.FormatFloat(c.Mean, 'f', 3, 64),
 		// Note this is the check boundary, not the largest Result seen
 		strconv.FormatFloat(m.MaxVal, 'f', 3, 64),
+		strconv.FormatFloat(m.Gap, 'f', 1, 64)+" %",
 		strconv.Itoa(c.Iterations),
 		strconv.FormatFloat(c.SD, 'f', 3, 64),
 		strconv.FormatFloat(c.CoV, 'f', 2, 64)+" %")...)

--- a/cmd/checkmetrics/main.go
+++ b/cmd/checkmetrics/main.go
@@ -133,7 +133,6 @@ func processMetricsBaseline(context *cli.Context) (err error) {
 	return
 }
 
-
 // processMetrics generates a report using the metrics results
 // available in CSV files provided as input without use a basefile
 // as reference. This report shows basic statitistics just in
@@ -153,7 +152,7 @@ func processMetrics(context *cli.Context) (err error) {
 		var thisCsv csvRecord
 		filepath := path.Join(mtrdir, csvf.Name())
 		err = thisCsv.load(filepath)
-		if  err != nil {
+		if err != nil {
 			return err
 		}
 
@@ -173,10 +172,9 @@ func processMetrics(context *cli.Context) (err error) {
 	return err
 }
 
-
 // System default path for baseline file
 // the value will be set by Makefile
-var sysBaseFile string = ""
+var sysBaseFile string
 
 // checkmetrics main entry point.
 // Do the command line processing, load the TOML file, and do the processing
@@ -208,7 +206,6 @@ func main() {
 			Usage: "directory containing CSV metrics",
 		},
 	}
-
 
 	app.Before = func(context *cli.Context) error {
 		var err error

--- a/cmd/checkmetrics/main.go
+++ b/cmd/checkmetrics/main.go
@@ -200,7 +200,7 @@ func main() {
 			Usage: "set the log file path",
 		},
 		cli.BoolFlag{
-			Name: "nobaseline",
+			Name:  "nobaseline",
 			Usage: "enable parsing metrics without basefile",
 		},
 		cli.StringFlag{

--- a/cmd/checkmetrics/metric.go
+++ b/cmd/checkmetrics/metric.go
@@ -23,4 +23,5 @@ type metrics struct {
 	Description string  `toml:"description"`
 	MinVal      float64 `toml:"minval"`
 	MaxVal      float64 `toml:"maxval"`
+	Gap         float64 // What is the % gap between the Min and Max vals
 }


### PR DESCRIPTION
It is useful to know how 'tight' the test checks are - what is the range or width of the 'band of acceptance' that is defined in the toml file.