### PR TITLE
CI: Add project name to checkcommits version output

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -70,6 +70,8 @@ const (
 
 	defaultCommit = "HEAD"
 	defaultBranch = "master"
+
+	versionSuffix = "for clear-containers"
 )
 
 var (
@@ -731,6 +733,14 @@ func main() {
 	app.UsageText += fmt.Sprintf("     if running in a supported CI environment (Travis or Semaphore).\n\n")
 	app.UsageText += fmt.Sprintf("   - If not running under a recognised CI environment, commit will default\n")
 	app.UsageText += fmt.Sprintf("     to %q and branch to %q.", defaultCommit, defaultBranch)
+
+	cli.VersionPrinter = func(c *cli.Context) {
+		// #nosec
+		fmt.Fprintf(os.Stdout, "%s version %s %s\n",
+			c.App.Name,
+			c.App.Version,
+			versionSuffix)
+	}
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{


### PR DESCRIPTION
Display the project name after the version details when
`checkcommits --version` is run for parity with the Kata Containers
version, but also to make merging between the projects easier.

Fixes #865.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>