### PR TITLE
Update scripts and test to work with latest CRI-O, k8s and openshift

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -71,6 +71,9 @@ crio_config_file="/etc/crio/crio.conf"
 echo "Set runc as default runtime in CRI-O for trusted workloads"
 sudo sed -i 's/^runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
 
+echo "Add docker.io registry to pull images"
+sudo sed -i 's/^registries = \[/registries = \[ "docker.io"/' /etc/crio/crio.conf
+
 echo "Set Clear containers as default runtime in CRI-O for untrusted workloads"
 sudo sed -i 's/default_workload_trust = "trusted"/default_workload_trust = "untrusted"/' "$crio_config_file"
 sudo sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/local\/bin\/cc-runtime"/' "$crio_config_file"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -79,6 +79,15 @@ then
         .ci/setup_tests.sh
 fi
 
+# Hack to make fetchbranches tool work under Jenkins.
+# This needs to be removed once https://github.com/clearcontainers/tests/issues/872
+# gets properly fixed.
+if [ ${ghprbPullId} ]; then
+	export PULL_REQUEST_NUMBER="${ghprbPullId}"
+	export SEMAPHORE=true
+	export SEMAPHORE_REPO_SLUG="${cc_repo/github.com\//}"
+fi
+
 # Make sure runc is default runtime.
 # This is needed in case a new image creation.
 # See https://github.com/clearcontainers/osbuilder/issues/8

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -15,16 +15,16 @@
 # limitations under the License.
 
 export KUBECONFIG=/etc/kubernetes/admin.conf
-sudo -E kubeadm reset
+sudo -E kubeadm reset --cri-socket=/var/run/crio/crio.sock
 sudo systemctl stop kubelet
 sudo systemctl stop docker
-for ctr in $(sudo crioctl ctr list | grep ^ID | cut -c5-); do
-	sudo crioctl ctr stop --id "$ctr"
-	sudo crioctl ctr remove --id "$ctr"
+for ctr in $(sudo crictl ps --quiet); do
+	sudo crictl stop "$ctr"
+	sudo crictl rm "$ctr"
 done
-for pod in $(sudo crioctl pod list | grep ^ID | cut -c5-); do
-	sudo crioctl pod stop --id "$pod"
-	sudo crioctl pod remove --id "$pod"
+for pod in $(sudo crictl sandboxes --quiet); do
+	sudo crictl stops "$pod"
+	sudo crictl rms "$pod"
 done
 
 sudo systemctl stop crio

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -18,7 +18,7 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib.sh"
 
-sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16
+sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16 --cri-socket=/var/run/crio/crio.sock
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 sudo -E kubectl get nodes

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -20,12 +20,15 @@ load "${BATS_TEST_DIRNAME}/lib.sh"
 setup() {
 	nginx_image="nginx"
 	busybox_image="busybox"
-	service_name="${nginx_image}-service"
+	service_name="nginx-service"
 	export KUBECONFIG=/etc/kubernetes/admin.conf
 	master=$(hostname)
 	sudo -E kubectl taint nodes "$master" node-role.kubernetes.io/master:NoSchedule-
-	sudo -E crioctl image pull "$busybox_image"
-	sudo -E crioctl image pull "$nginx_image"
+	# Pull the images before launching workload. This is mainly because we use
+	# a timeout and in slow networks it may result in not been able to pull the image
+	# successfully.
+	sudo -E crictl pull "$busybox_image"
+	sudo -E crictl pull "$nginx_image"
 }
 
 @test "Verify nginx connectivity between pods" {

--- a/integration/kubernetes/setup.sh
+++ b/integration/kubernetes/setup.sh
@@ -37,5 +37,5 @@ popd
 
 echo "Modify kubelet systemd configuration to use CRI-O"
 k8s_systemd_file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-sudo sed -i '/KUBELET_AUTHZ_ARGS/a Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=/var/run/crio.sock --runtime-request-timeout=30m"' "$k8s_systemd_file"
+sudo sed -i '/KUBELET_AUTHZ_ARGS=/a Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --runtime-request-timeout=30m"' "$k8s_systemd_file"
 sudo systemctl daemon-reload

--- a/integration/openshift/data/hello-pod-cc.json
+++ b/integration/openshift/data/hello-pod-cc.json
@@ -15,7 +15,7 @@
     "containers": [
       {
         "name": "hello-openshift",
-        "image": "openshift/hello-openshift",
+        "image": "docker.io/openshift/hello-openshift",
         "ports": [
           {
             "containerPort": 8080,

--- a/integration/openshift/hello_world.bats
+++ b/integration/openshift/hello_world.bats
@@ -27,7 +27,7 @@ setup() {
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 	pod_name="hello-openshift"
 	image="openshift/${pod_name}"
-	sudo -E /usr/local/bin/crioctl image pull "$image"
+	sudo -E crictl pull "$image"
 	cc_runtime_bin=$(command -v cc-runtime)
 }
 

--- a/integration/openshift/init.sh
+++ b/integration/openshift/init.sh
@@ -35,15 +35,13 @@ kubeletArguments:
   node-labels:
   - region=infra
   image-service-endpoint:
-  - "/var/run/crio.sock"
+  - "unix:///var/run/crio/crio.sock"
   container-runtime-endpoint:
-  - "/var/run/crio.sock"
+  - "unix:///var/run/crio/crio.sock"
   container-runtime:
   - "remote"
   runtime-request-timeout:
   - "15m"
-  enable-cri:
-  - "true"
   cgroup-driver:
   - "cgroupfs"
 EOF


### PR DESCRIPTION
Now that we are moving to CRI-O v1.9, the crioctl tool has
been deprecated, instead we need to use crictl for our tests.

Also, k8s v1.9.1 and openshift v3.7.1 changed the configuration slightly.
This PR addresses all issues to be able to move to these newer
versions. 

Depends on: 

Fixes: #867.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>