### PR TITLE
ci: metrics: improve density tests interaction with KSM

### DIFF
--- a/metrics/density/README.md
+++ b/metrics/density/README.md
@@ -7,7 +7,20 @@ This number of containers could be working under different configurations/condit
 - `docker_memory_usage.sh`: measures the Proportional Set Size (PSS) memory average
    for a number of containers launched in idle mode. This test uses the `sleep` command
    to allow any memory optimizations to 'settle' (e.g. KSM execution) for a configurable
-   period of time.
+   period of time. It also has an optional 'auto' mode which will try to determine when KSM
+   has settled down by examining the KSM `full_scans` and `pages_shared` values. auto mode
+   detection of KSM settling over-rides the timeout value for taking the measurements and
+   completing the test.
+- `docker_memory_usage.sh`: measures the Proportional Set Size (PSS) memory average
+   for a number of containers launched in idle mode. 
+   The test has two methods that can be utilized to wait for `KSM` to 'settle'.
+    - The test sleeps for the amount of time specified by the 'timeout', which is
+      in seconds, before taking measurements.
+    - If `auto` mode is enabled, the test terminates `timeout` early
+      under the condition that 'KSM' has already settled, which
+      is determined by exmaining the `KSM` `full_scans` and `pages_shared`
+      information.
+
 - `footprint_data.sh`: Sequentially runs a number of identical containers and takes a
    number of memory related measurements after each launch. Generally not used in a CI
    type environment, but more for hand run/analysis. Refer to the


### PR DESCRIPTION
Previously we were fairly benign about our interactions with KSM - we just turned it on/off and depended on the distro default settings, whilst also hard wiring a sleep (300s) to try and ensure KSM page merging had settled down before taking our measurements.

Let's be a bit smarter by:
 - setting some aggressive KSM settings that we define
 - actively monitoring KSM to try and spot when it 'settles'

A few benefits fall out of this (on my test system):
 - the KSM density test now completes in ~123s, rather than 300s (my original goal)
 - the density result is significantly smaller - it would seem 300s was not enough to wait for KSM to really settle!
 - the result is more repeatable (CoV of ~0.3 instead of ~0.4 - it was pretty good already, and now it is even better)
