### PR TITLE
CI: Change handling of git PR branch

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -51,7 +51,12 @@ fi
 # Get the repository and move to the correct commit
 go get ${cc_repo} || true
 pushd ${GOPATH}/src/${cc_repo}
-if [ ${ghprbPullId} ] && [ ${ghprbTargetBranch} ]
+
+pr_number=
+
+[ "${ghprbPullId}" ] && [ "${ghprbTargetBranch}" ] && pr_number="${ghprbPullId}"
+
+if [ -n "$pr_number" ]
 then
 	# For PRs we rebase the PR commits onto the defined target branch
 	git fetch origin "pull/${ghprbPullId}/head" && git checkout master && git reset --hard FETCH_HEAD && git rebase origin/${ghprbTargetBranch}

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -73,9 +73,17 @@ then
         .ci/setup_tests.sh
 fi
 
-# Set up the distro environment. Get, build and install all the latest
-# components
-.ci/setup.sh
+# Call the repo-specific setup script.
+#
+# It is assumed this script will:
+#
+# - Call "${tests_repo}/.ci/setup.sh"
+#
+#   This will setup the distro environment (get, build and install all the
+#   latest components).
+#
+# - Call checkcommits.
+bash "${GOPATH}/src/${cc_repo}/.ci/setup.sh"
 
 # The metrics CI does not need to do the QA checks - it only runs once
 # it knows the QA CI has passed already.


### PR DESCRIPTION
Rather than merging the PR commits directly into `master`, create a separate
branch for the PR.

This allows `checkcommits` to determine the changes the PR introduces.

After `checkcommits` has run, merge the PR branch back into `master` since
this is required for coveralls.

Fixes #876.