### PR TITLE
ci: Fix image build  using docker.

### DIFF
--- a/.ci/install_asset.sh
+++ b/.ci/install_asset.sh
@@ -119,7 +119,7 @@ function build_asset {
 		image)
 			packaging="github.com/${repo_owner}/packaging"
 			go get -d -u  ${packaging} || true
-			"$GOPATH/src/${packaging}/release-tools/release_image_github.sh" -o "${PWD}" -a ${cc_agent_version} -c ${clear_vm_image_version} release
+			sudo -E "$GOPATH/src/${packaging}/release-tools/release_image_github.sh" -o "${PWD}" -a ${cc_agent_version} -c ${clear_vm_image_version} release
 			;;
 		*)
 			die "Dont know how to build $asset"


### PR DESCRIPTION
When building an image k8s ci breaks because the user has not
access to docker socket.

Fixes: #882

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>