### PR TITLE
CI: Do not build, but do update, repos when pulling them

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -48,10 +48,11 @@ then
 	go get github.com/mattn/goveralls
 fi
 
-# Get the repository and move to the correct commit
-go get ${cc_repo} || true
+# Get or update the repository, but do not build.
+go get -d -u ${cc_repo} || true
 pushd ${GOPATH}/src/${cc_repo}
 
+# And move to the correct commit
 pr_number=
 
 [ "${ghprbPullId}" ] && [ "${ghprbTargetBranch}" ] && pr_number="${ghprbPullId}"


### PR DESCRIPTION
Without a '-d' on the 'go get', the script ties to build the repos,
and for repos that do not work under 'go build', this leaves errors
in the CI logs. We don't need a build at this stage as we invoke the
repo specific builds later on.
Also, some CIs do not clean out their build trees between builds, and
thus have repos already present - so add an 'update -u' flag as well.

Fixes: #887

Signed-off-by: Graham Whaley <graham.whaley@intel.com>