### PR TITLE
ctr_mgr: Remove newgroup command from installation

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -157,7 +157,6 @@ install_docker(){
 	sudo systemctl restart docker
 	sudo gpasswd -a ${USER} docker
 	sudo chmod g+rw /var/run/docker.sock
-	newgrp docker
 }
 
 # This function removes the installed docker package.


### PR DESCRIPTION
newgrp command was introduced to login into the docker
group and allow a normal user execute the runtime
unit tests which require the use of docker without
root, but this command didn't had the desired effect
on the CI and when running under a terminal it creates
a new bash session, stopping the installation of all
other components. For this reason, lets remove this
command from the docker installation.

Fixes #890.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>