### PR TITLE
ci: Add go-md2man, which is cri-o dependency

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -27,6 +27,9 @@ pushd "${GOPATH}/src/${crio_repo}"
 git fetch
 git checkout "${crio_version}"
 
+# Add link of go-md2man to $GOPATH/bin
+ln -s $(command -v go-md2man) $GOPATH/bin/
+
 echo "Get CRI Tools"
 critools_repo="github.com/kubernetes-incubator/cri-tools"
 go get "$critools_repo" || true

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -48,7 +48,7 @@ echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel 	  \
 	glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel  \
 	libgpg-error-devel libseccomp-devel libselinux-devel ostree-devel \
-	pkgconfig
+	pkgconfig go-md2man
 
 echo "Install bison binary"
 chronic sudo -E dnf -y install bison

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -43,7 +43,7 @@ echo "Install qemu-lite binary"
 "${cidir}/install_qemu_lite.sh" "${qemu_lite_clear_release}" "${qemu_lite_sha}" "$ID"
 
 echo "Install CRI-O dependencies for all Ubuntu versions"
-chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev
+chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev go-md2man
 
 echo "Install bison binary"
 chronic sudo -E apt install -y bison


### PR DESCRIPTION
Instead of get go-md2man from github repository and build
latest version of the tool, install stable version from fedora
and ubuntu packages.

Fixes #892.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>