### PR TITLE
ci: Set runc as default runtime for image creation

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -79,6 +79,11 @@ then
         .ci/setup_tests.sh
 fi
 
+# Make sure runc is default runtime.
+# This is needed in case a new image creation.
+# See https://github.com/clearcontainers/osbuilder/issues/8
+"${GOPATH}/${tests_repo}/cmd/container-manager/manage_ctr_mgr.sh" docker configure -r runc  -f || true
+
 # Call the repo-specific setup script.
 #
 # It is assumed this script will:


### PR DESCRIPTION
jenkins may use cc-runtime as default runtime.
This is an issue when an image need to be created with osbuilder.

This commit tries to set runc as default runtime. If is not possible
(because docker not installed), the setup will continue.

Fixes: #897

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>