### PR TITLE
Refine metrics CI invocations

### DIFF
--- a/.ci/run_metrics_ci.sh
+++ b/.ci/run_metrics_ci.sh
@@ -125,18 +125,8 @@ pushd "$CURRENTDIR/../metrics"
 	# ops/second
 	bash network/network-nginx-ab-benchmark.sh
 
-	# ping latency
-	bash network/network-latency.sh
-
-	# qperf latency
-	bash network/network-latency-qperf.sh
-
-	# Bandwidth and jitter
+	# iperf3 bandwidth between host and container
 	bash network/network-metrics-iperf3.sh -B -i 8
-
-	# UDP bandwidths and packet loss
-	bash network/network-metrics-nuttcp.sh
-
 
 	#
 	# Run some IO tests

--- a/.ci/run_metrics_ci.sh
+++ b/.ci/run_metrics_ci.sh
@@ -132,7 +132,7 @@ pushd "$CURRENTDIR/../metrics"
 	bash network/network-latency-qperf.sh
 
 	# Bandwidth and jitter
-	bash network/network-metrics-iperf3.sh
+	bash network/network-metrics-iperf3.sh -B -i 8
 
 	# UDP bandwidths and packet loss
 	bash network/network-metrics-nuttcp.sh

--- a/metrics/network/README.md
+++ b/metrics/network/README.md
@@ -35,7 +35,9 @@ and packet-per-second throughput using iperf3 on single threaded connections.
 The bandwidth test shows the speed of the data transfer. On the other hand,
 the jitter test measures the variation in the delay of received packets.
 The packet-per-second tests show the maximum number of (smallest sized) packets
-we can get through the transports.
+allowed through the transports.  
+Command-line options choose what tests to run, for how long, and
+how many iterations to execute.
 
 - `network-metrics-nuttcp`: measures the UDP bandwidth using nuttcp. This tool
 shows the speed of the data transfer for the UDP protocol.


### PR DESCRIPTION
Refine our metrics CI invocations somewhat:
- stop running tests that we don't currently check the results for
- refine the iperf3 test run to only test what we do check
    - which involved adding a commandline to the iperf3 test so we could tweak it