### PR TITLE
ci: clone tests repo on jenkins_job_build.sh

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -77,6 +77,8 @@ fi
 if [ "${cc_repo}" == "${tests_repo}" ]
 then
         .ci/setup_tests.sh
+else
+	go get "${tests_repo}"
 fi
 
 # Make sure runc is default runtime.


### PR DESCRIPTION
If jenkins_job_build is called from other repository than
`tests`, the `tests` repo will not be in the $GOPATH tree and
the `manage_ctr_mgr,sh` call will not work. For that reason, we
need to clone tests repo using `go get`.

Fixes #914.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>