### PR TITLE
integration: crio: Update bats to match latest version from CRI-O

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -86,5 +86,3 @@ sudo cp "${crio_service_file}" "${service_path}"
 
 echo "Reload systemd services"
 sudo systemctl daemon-reload
-echo "Start crio service"
-sudo systemctl restart crio

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ RUNTIME ?= cc-runtime
 TIMEOUT ?= 150
 
 CRIO_REPO_PATH="${GOPATH}/src/github.com/kubernetes-incubator/cri-o"
+CRIO_INTEG_PATH="integration/cri-o"
 crio:
 	bash .ci/install_bats.sh
-	cp $(PWD)/integration/cri-o/crio.bats ${CRIO_REPO_PATH}/test/
+	cp $(PWD)/${CRIO_INTEG_PATH}/crio.bats ${CRIO_REPO_PATH}/test/
+	cd ${CRIO_INTEG_PATH} && ./init.sh
 	cd ${CRIO_REPO_PATH} && \
 	RUNTIME=${RUNTIME} STORAGE_OPTS="${CRIO_STORAGE_DRIVER_OPTS}" ./test/test_runner.sh crio.bats
 

--- a/integration/cri-o/init.sh
+++ b/integration/cri-o/init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# CRI-O service needs to be stopped here since the bats being run as part
+# of the CRI-O integration tests actually start/stop the crio binary directly.
+# That's why we don't want the crio service to be running at the same time,
+# otherwise we end up with two binaries running at the same time, and stopping
+# the binary fails since the system automatically restart the service if it is
+# killed (which is the way the bats stop the binary).
+echo "Stop crio service"
+sudo systemctl stop crio

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -18,6 +18,9 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib.sh"
 
+echo "Start crio service"
+sudo systemctl start crio
+
 sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16 --cri-socket=/var/run/crio/crio.sock
 export KUBECONFIG=/etc/kubernetes/admin.conf
 

--- a/integration/openshift/init.sh
+++ b/integration/openshift/init.sh
@@ -19,6 +19,9 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/openshiftrc"
 
+echo "Start crio service"
+sudo systemctl start crio
+
 echo "Disable SELinux"
 echo "There is an issue when runnig CRI-O workloads with SELinux enabled
 For more information, please take a look at:


### PR DESCRIPTION
This commit entirely relies on the latest version of CRIO in order
to update the bats properly. This is a simple copy/paste of the tests
we already support, but it updates the content to the latest version.

Fixes #918

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>