### PR TITLE
CI: Integrate Kubernetes testing in the CI flow

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -60,6 +60,8 @@ bash -f ${cidir}/install_cni_plugins.sh
 echo "Install CRI-O"
 bash -f ${cidir}/install_crio.sh
 
+bash -f "${cidir}/install_kubernetes.sh"
+
 bash -f "${cidir}/openshift_setup.sh"
 
 echo "Drop caches"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ metrics:
 integration: ginkgo
 	./ginkgo -v -focus "${FOCUS}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout ${TIMEOUT}
 
+kubernetes:
+	bash -f .ci/install_bats.sh
+	bash -f integration/kubernetes/run_kubernetes_tests.sh
+
 openshift:
 	bash .ci/install_bats.sh
 	cd integration/openshift && \
@@ -53,7 +57,7 @@ swarm:
 conformance:
 	bats conformance/posixfs/fstest.bats
 
-check: functional crio integration conformance
+check: functional crio integration conformance kubernetes
 
 all: functional checkcommits integration
 
@@ -63,4 +67,4 @@ checkcommits:
 clean:
 	cd cmd/checkcommits && make clean
 
-.PHONY: functional check ginkgo crio metrics integration conformance
+.PHONY: functional check ginkgo crio metrics integration conformance kubernetes

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -15,8 +15,16 @@
 # limitations under the License.
 
 set -e
+
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/lib.sh"
+
+# The next workaround is to be able to communicate between pods
+# Issue: https://github.com/kubernetes/kubernetes/issues/40182
+# Fix is ready for K8s 1.9, but still need to investigate why it does not
+# work by default.
+# FIXME: Issue: https://github.com/clearcontainers/tests/issues/934
+sudo iptables -P FORWARD ACCEPT
 
 echo "Start crio service"
 sudo systemctl start crio

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /etc/os-release
+kubernetes_dir=$(dirname $0)
+
+# Currently, Kubernetes tests only work on Ubuntu.
+# We should delete this condition, when it works for other Distros.
+if [ "$ID" != ubuntu  ]; then
+    echo "Skip - kubernetes tests on $ID aren't supported yet"
+    exit
+fi
+
+pushd "$kubernetes_dir"
+./init.sh
+bats nginx.bats
+./cleanup_env.sh
+popd


### PR DESCRIPTION
With these changes, k8s will be tested with the jenkins
jobs instead of using localCI.

Fixes #928.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>