### PR TITLE
CI: call release_image_github.sh script without sudo

### DIFF
--- a/.ci/install_asset.sh
+++ b/.ci/install_asset.sh
@@ -120,7 +120,7 @@ function build_asset {
 		image)
 			packaging="github.com/${repo_owner}/packaging"
 			go get -d -u  ${packaging} || true
-			sudo -E "$GOPATH/src/${packaging}/release-tools/release_image_github.sh" -o "${PWD}" -a ${cc_agent_version} -c ${clear_vm_image_version} release
+			"$GOPATH/src/${packaging}/release-tools/release_image_github.sh" -o "${PWD}" -a ${cc_agent_version} -c ${clear_vm_image_version} release
 			;;
 		*)
 			die "Dont know how to build $asset"


### PR DESCRIPTION
We don't want to call release_image_github.sh using sudo,
as we end up having $GOPATH/bin been owned by root.
As https://github.com/clearcontainers/packaging/pull/277
is now merged, we can remove sudo.

Fixes: #932.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>