### PR TITLE
integration/docker: Skip CPU tests

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -251,6 +251,7 @@ var _ = Describe("run", func() {
 
 	DescribeTable("container with CPU period and quota",
 		func(quota, period int, fail bool) {
+			Skip("Issue: https://github.com/clearcontainers/tests/issues/936")
 			args = append(args, "--cpu-quota", fmt.Sprintf("%d", quota),
 				"--cpu-period", fmt.Sprintf("%d", period), Image, "nproc")
 			vCPUs = (quota + period - 1) / period
@@ -270,6 +271,7 @@ var _ = Describe("run", func() {
 
 	DescribeTable("container with CPU constraint",
 		func(cpus int, fail bool) {
+			Skip("Issue: https://github.com/clearcontainers/tests/issues/936")
 			args = append(args, "--cpus", fmt.Sprintf("%d", cpus), Image, "nproc")
 			stdout, _, exitCode := DockerRun(args...)
 			if fail {


### PR DESCRIPTION
containers/virtcontainers#512 introduces new changes in the way CPUs are handled
this patch skips CPU tests to allow containers/virtcontainers#512 get merged.

fixes #937

Signed-off-by: Julio Montes <julio.montes@intel.com>