### PR TITLE
manage_ctr_mgr: change the way we switch docker runtimes

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -218,6 +218,12 @@ modify_docker_service(){
 	elif [ "$(ls -A $docker_service_dir)" ] && [ ${force} == true ]; then
 		rm -rf "${docker_service_dir}/*"
 	fi
+	echo "Stopping the docker service"
+	sudo systemctl stop docker
+	dir="/var/lib/docker"
+	echo "Removing $dir"
+	[ -d "$dir" ] && sudo rm -rf "$dir"
+	echo "Changing docker service configuration"
 	sudo mkdir -p "$docker_service_dir"
 	cat <<EOF | sudo tee "$docker_service_dir/clear-containers.conf"
 [Service]
@@ -226,7 +232,7 @@ Environment="$docker_https_proxy"
 ExecStart=
 ExecStart=/usr/bin/dockerd ${docker_options}
 EOF
-	echo "Restart docker service"
+	echo "Reloading unit files and starting docker service"
 	sudo systemctl daemon-reload
 	sudo systemctl restart docker
 }
@@ -249,16 +255,16 @@ configure_docker(){
 			docker_http_proxy="HTTP_PROXY=$http_proxy"
 			docker_https_proxy="HTTPS_PROXY=$https_proxy"
 		fi
-
+		storage_driver="overlay2"
 		if [ "$runtime" == "cc-runtime" ]  ; then
 			# Try to find cc-runtime in $PATH, if it is not present
 			# then the default location will be /usr/local/bin/cc-runtime
 			cc_runtime_bin="$(which $runtime)" || \
 				die "$runtime cannot be found in $PATH, please make sure it is installed"
-			docker_options="-D --add-runtime $runtime=$cc_runtime_bin --default-runtime=$runtime --storage-driver=overlay2"
+			docker_options="-D --add-runtime $runtime=$cc_runtime_bin --default-runtime=$runtime --storage-driver=$storage_driver"
 			modify_docker_service "$docker_options"
 		elif [ "$runtime" == "runc" ]  ; then
-			docker_options="-D"
+			docker_options="-D --storage-driver=$storage_driver"
 			modify_docker_service "$docker_options"
 		else
 			die "configure_docker: runtime $runtime not supported"


### PR DESCRIPTION
Specify storage-driver=overlay2 when changing runtime to runc.
Alsoi when changing runtimes, first stop the service,
remove /var/lib/docker, then change the configuration and
restart the service.
Fixes: #939.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>