### PR TITLE
CI: add set -e to run_kubernetes_tests.sh

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 source /etc/os-release
 kubernetes_dir=$(dirname $0)
 


### PR DESCRIPTION
Add `set -e` to fail if a command does not return
successful.

Fixes: #946.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>