### PR TITLE
CI: do not hold kubernetes packages

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -34,7 +34,6 @@ EOF"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo -E apt update
 sudo -E apt install -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
-sudo -E apt-mark hold kubelet kubeadm kubectl
 
 echo "Modify kubelet systemd configuration to use CRI-O"
 k8s_systemd_file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"


### PR DESCRIPTION
There is no need to hold the kubernetes packages to
a specific version in the CI. Holding them was preventing
the metrics CI node to fail installing the correct packages.

Fixes: #950

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>