### PR TITLE
metrics: do not restart proxy any more

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -107,9 +107,6 @@ function onetime_init()
 
 	# Restart services
 	sudo systemctl restart docker
-	if [[ "${RUNTIME}" == "cor" || "${RUNTIME}" == "cc-runtime" ]];then
-		sudo systemctl restart cc-proxy
-	fi
 
 	# We want this to be seen in sub shells as well...
 	# otherwise init_env() cannot check us


### PR DESCRIPTION
We no longer have a global cc proxy systemd service, so do not
try to restart it during metrics system initialisation.

Fixes: #952

Signed-off-by: Graham whaley <graham.whaley@intel.com>