### PR TITLE
metrics: add support for kata-runtime

### DIFF
--- a/integration/swarm/swarm.bats
+++ b/integration/swarm/swarm.bats
@@ -119,5 +119,5 @@ teardown() {
 	$DOCKER_EXE service remove "${SERVICE_NAME}"
 	$DOCKER_EXE swarm leave --force
 	check_processes ${HYPERVISOR_PATH}
-	check_processes ${CC_SHIM_PATH}
+	check_processes ${SHIM_PATH}
 }

--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -211,7 +211,7 @@ function get_docker_memory_usage(){
 		runc_workload_mem="$(get_runc_pss_memory)"
 		memory_usage="$runc_workload_mem"
 
-	elif [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ]; then
+	elif [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ] || [ "$RUNTIME" == "kata-runtime" ]; then
 		# Get PSS memory of CC components.
 		# And check that the smem search has found the process - we get a "0"
 		#  back if that procedure fails (such as if a process has changed its name
@@ -229,14 +229,14 @@ function get_docker_memory_usage(){
 			die "Failed to find PSS for $QEMU_PATH"
 		fi
 
-		cc_shim_mem="$(get_pss_memory "$CC_SHIM_PATH")"
+		cc_shim_mem="$(get_pss_memory "$SHIM_PATH")"
 		if [ "$cc_shim_mem" == "0" ]; then
-			die "Failed to find PSS for $CC_SHIM_PATH"
+			die "Failed to find PSS for $SHIM_PATH"
 		fi
 
-		proxy_mem="$(get_pss_memory "$CC_PROXY_PATH")"
+		proxy_mem="$(get_pss_memory "$PROXY_PATH")"
 		if [ "$proxy_mem" == "0" ]; then
-			die "Failed to find PSS for $CC_PROXY_PATH"
+			die "Failed to find PSS for $PROXY_PATH"
 		fi
 
 		cc_proxy_mem="$(bc -l <<< "scale=2; $proxy_mem / $NUM_CONTAINERS")"

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -77,10 +77,10 @@ MIN_MEMORY_FREE="${MIN_MEMORY_FREE:-2*1024*1024*1024}"
 
 # Proxy and shim paths come from common.bash
 # You can over-ride them in your env
-#CC_PROXY_PATHPROXY
-#CC_SHIM_PATH
+#PROXY_PATH
+#SHIM_PATH
 # Use the magic in common.bash to find the correct QEMU path
-CC_QEMU_PATH="${CC_QEMU_PATH:-get_qemu_path}"
+QEMU_PATH="${QEMU_PATH:-get_qemu_path}"
 
 # We monitor dockerd as we know it can grow as we run containers
 DOCKERD_PATH="${DOCKERD_PATH:-/usr/bin/dockerd}"
@@ -133,6 +133,8 @@ function cleanup() {
 
 # helper function to get USS of prcess in arg1
 function get_proc_uss() {
+	[[ -z "$1" ]] && echo 0 && return
+
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $4}')
 	((item*=1024))
 	echo $item
@@ -140,6 +142,8 @@ function get_proc_uss() {
 
 # helper function to get PSS of prcess in arg1
 function get_proc_pss() {
+	[[ -z "$1" ]] && echo 0 && return
+
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $5}')
 	((item*=1024))
 	echo $item
@@ -152,9 +156,9 @@ function grab_cc_uss() {
 		return
 	fi
 
-	proxy=$(get_proc_uss $CC_PROXY_PATH)
-	shim=$(get_proc_uss $CC_SHIM_PATH)
-	qemu=$(get_proc_uss $CC_QEMU_PATH)
+	proxy=$(get_proc_uss $PROXY_PATH)
+	shim=$(get_proc_uss $SHIM_PATH)
+	qemu=$(get_proc_uss $QEMU_PATH)
 
 	total=$((proxy + shim + qemu))
 	echo -n ", $total" >> $DATAFILE
@@ -167,9 +171,9 @@ function grab_cc_pss() {
 		return
 	fi
 
-	proxy=$(get_proc_pss $CC_PROXY_PATH)
-	shim=$(get_proc_pss $CC_SHIM_PATH)
-	qemu=$(get_proc_pss $CC_QEMU_PATH)
+	proxy=$(get_proc_pss $PROXY_PATH)
+	shim=$(get_proc_pss $SHIM_PATH)
+	qemu=$(get_proc_pss $QEMU_PATH)
 
 	total=$((proxy + shim + qemu))
 	echo -n ", $total" >> $DATAFILE
@@ -374,7 +378,7 @@ function show_vars()
 	echo -e "\t\tThe maximum amount of memory to be consumed before terminating"
 	echo -e "\tMIN_MEMORY_FREE (${MIN_MEMORY_FREE})"
 	echo -e "\t\tThe minimum amount of memory allowed to be free before terminating"
-	echo -e "\tCC_QEMU_PATH (${CC_QEMU_PATH})"
+	echo -e "\tQEMU_PATH (${QEMU_PATH})"
 	echo -e "\t\tThe path to the Clear Containers QEMU binary (for 'smem' measurements)"
 	echo -e "\tDOCKERD_PATH (${DOCKERD_PATH})"
 	echo -e "\t\tThe path to the Docker 'dockerd' binary (for 'smem' measurements)"

--- a/metrics/storage/fio_job.sh
+++ b/metrics/storage/fio_job.sh
@@ -200,7 +200,7 @@ function main()
 	# be measured
 	if [ "$RUNTIME" == "runc" ]; then
 		PROCESS="fio"
-	elif [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ]; then
+	elif [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ] || [ "$RUNTIME" == "kata-runtime" ]; then
 		PROCESS=${QEMU_PATH}
 	else
 		die "Unknown runtime: $RUNTIME"

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -102,6 +102,16 @@ run_workload() {
 				${workload_result[@]}
 			EOF
 			) | tail -1 )
+
+		if [ -z "$kernel_last_line" ]; then
+			echo "No kernel last line"
+			for l in "${workload_result[@]}"; do
+				echo ">: [$l]"
+			done
+			die "No kernel last line"
+		fi
+
+
 		kernel_period=$(echo $kernel_last_line | awk '{print $2}' | tr -d "]")
 
 		# And we can then work out how much time it took to get to the kernel
@@ -214,6 +224,7 @@ main() {
 
 	init
 	for i in $(seq 1 "$TIMES"); do
+		echo " run $i"
 		run_workload
 	done
 	clean_env

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -141,7 +141,7 @@ init () {
 	echo "Executing test: ${TEST_NAME} ${TEST_ARGS}"
 	check_cmds "${REQUIRED_CMDS[@]}"
 
-	if [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ]; then
+	if [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ] || [ "$RUNTIME" == "kata-runtime" ] ; then
 		CALCULATE_KERNEL=1
 		DMESGCMD="; dmesg"
 	else


### PR DESCRIPTION
Whilst we transition metrics over to the kata repos, it will be very helpful to be able to run the metrics here on a kata-runtime.
Add kata-runtime recognition support to the metrics scripts.
