### PR TITLE
metrics: Add FIO flags to produce stable results.

### DIFF
--- a/.ci/run_metrics_ci.sh
+++ b/.ci/run_metrics_ci.sh
@@ -131,10 +131,14 @@ pushd "$CURRENTDIR/../metrics"
 	#
 	# Run some IO tests
 	#
-	bash storage/fio_job.sh -b 16k -o randread -t "storage IO random read bs 16k"
-	bash storage/fio_job.sh -b 16k -o randwrite -t "storage IO random write bs 16k"
-	bash storage/fio_job.sh -b 16k -o read -t "storage IO linear read bs 16k"
-	bash storage/fio_job.sh -b 16k -o write -t "storage IO linear write bs 16k"
+	# Block Size and Ramp Time Settings for Fio Test
+	BLOCK_SIZE="16k"
+	RAMP_TIME="60"
+
+	bash storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o randread -t "storage IO random read bs ${BLOCK_SIZE}"
+	bash storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o randwrite -t "storage IO random write bs ${BLOCK_SIZE}"
+	bash storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o read -t "storage IO linear read bs ${BLOCK_SIZE}"
+	bash storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o write -t "storage IO linear write bs ${BLOCK_SIZE}"
 
 	# If we are running under a CI, the do some extra work
 	# We check we are under a CI before doing this, as that still leaves us

--- a/metrics/run_all_metrics.sh
+++ b/metrics/run_all_metrics.sh
@@ -95,10 +95,15 @@ function run_memory_tests() {
 # Only run I/O storage metrics tests
 function run_storage_tests() {
 	# Run I/O storage tests
-	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o randread -t "storage IO random read bs 16k"
-	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o randwrite -t "storage IO random write bs 16k"
-	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o read -t "storage IO linear read bs 16k"
-	bash ${SCRIPT_PATH}/storage/fio_job.sh -b 16k -o write -t "storage IO linear write bs 16k"
+
+	# Block Size and Ramp Time Settings for Fio Test
+        BLOCK_SIZE="16k"
+        RAMP_TIME="60"
+
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o randread -t "storage IO random read bs ${BLOCK_SIZE}"
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o randwrite -t "storage IO random write bs ${BLOCK_SIZE}"
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o read -t "storage IO linear read bs ${BLOCK_SIZE}"
+	bash ${SCRIPT_PATH}/storage/fio_job.sh -b ${BLOCK_SIZE} -u ${RAMP_TIME} -o write -t "storage IO linear write bs ${BLOCK_SIZE}"
 }
 
 # Run all metrics tests


### PR DESCRIPTION
Add FIO flags like time_based, drop host pages,
invalidate, direct, etc to produce more stable results.

Fixes #956

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>