### PR TITLE
ci: prevent cri-o installation script fail.

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -33,7 +33,7 @@ if [ ! -d "$GOBIN" ]
 then
 	mkdir -p "$GOBIN"
 fi
-ln -s $(command -v go-md2man) "$GOBIN"
+ln -sf $(command -v go-md2man) "$GOBIN"
 
 echo "Get CRI Tools"
 critools_repo="github.com/kubernetes-incubator/cri-tools"
@@ -62,6 +62,7 @@ popd
 echo "Install runc for CRI-O"
 go get -d github.com/opencontainers/runc
 pushd "${GOPATH}/src/github.com/opencontainers/runc"
+git fetch
 git checkout "$runc_version"
 make
 sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"


### PR DESCRIPTION
Fix:
- The script does not fetch before checkout.
- It fails if go-md2man symlink already exist.

Fixes: #961

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>