### PR TITLE
tests: tests cc-runtime as default runtime for cri-containerd

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -18,8 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-
-tmp_dir=$(mktemp -d -t tmp.XXXXXXXXXX)
+tmp_dir=$(mktemp -d -t cri-containerd-install.XXXXXXXXXX)
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 finish() {
@@ -39,8 +38,7 @@ info() {
 trap finish EXIT
 
 source "${script_dir}/lib.sh"
-get_cc_versions
-
+#get_cc_versions
 #TODO (jcvenega) remove after https://github.com/clearcontainers/runtime/pull/1091 is merged
 cri_containerd_version="v1.0.0-rc.0"
 
@@ -52,7 +50,8 @@ git fetch
 info "Checkout to ${cri_containerd_version}"
 git checkout "${cri_containerd_version}"
 info "Installing cri-containerd"
-make install.tools
 make install.deps
 make
 sudo -E PATH=$PATH make install
+#TODO (carlos) : Fedora does not look for /usr/local with sudo.
+sudo cp /usr/local/bin/containerd-shim /usr/bin/containerd-shim

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# 
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+tmp_dir=$(mktemp -d -t tmp.XXXXXXXXXX)
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+finish() {
+  rm -rf "$tmp_dir"
+}
+
+die() {
+	echo >&2 -e "\e[1mERROR\e[0m: $*"
+	exit 1
+}
+
+info() {
+	echo -e "\e[1mINFO\e[0m: $*"
+}
+
+
+trap finish EXIT
+
+source "${script_dir}/lib.sh"
+get_cc_versions
+
+#TODO (jcvenega) remove after https://github.com/clearcontainers/runtime/pull/1091 is merged
+cri_containerd_version="v1.0.0-rc.0"
+
+info "Get cri containerd sources"
+repo="github.com/containerd/cri"
+go get -d "$repo" || true
+pushd "${GOPATH}/src/${repo}"
+git fetch
+info "Checkout to ${cri_containerd_version}"
+git checkout "${cri_containerd_version}"
+info "Installing cri-containerd"
+make install.tools
+make install.deps
+make
+sudo -E PATH=$PATH make install

--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+tmp_dir=$(mktemp -d -t install-go-tmp.XXXXXXXXXX)
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_name="$(basename "${BASH_SOURCE[0]}")"
+USE_VERSIONS_FILE=""
+PROJECT="Clear Containers"
+
+finish() {
+	rm -rf "$tmp_dir"
+}
+
+die() {
+	echo >&2 -e "\e[1mERROR\e[0m: $*"
+	exit 1
+}
+
+info() {
+	echo -e "\e[1mINFO\e[0m: $*"
+}
+
+usage(){
+	exit_code="$1"
+	cat <<EOT
+Usage:
+
+${script_name} [options] <args>
+
+Args:
+<go-version> : Install a specific go version.
+
+Example:
+${script_name} 1.10
+
+
+Options
+-p : Install go defined in ${PROJECT} versions file.
+-h : Show this help
+
+EOT
+exit "$exit_code"
+}
+
+
+trap finish EXIT
+
+pushd "${tmp_dir}"
+
+while getopts hp opt
+do
+	case $opt in
+		h)	usage 0 ;;
+		p)	USE_VERSIONS_FILE="true"
+	esac
+done
+
+
+go_version="${1:-""}"
+if [ -z "$go_version" ];then
+	usage 0
+elif [ -n "${USE_VERSIONS_FILE}" ] ;then
+	source "${script_dir}/lib.sh"
+	get_cc_versions
+fi
+
+
+
+info "Download go version ${go_version}"
+curl -OL https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz
+info "Remove old go installation"
+sudo rm -r /usr/local/go/
+info "Install go"
+sudo tar -C /usr/local -xzf go${go_version}.linux-amd64.tar.gz
+popd
+
+

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -16,6 +16,7 @@
 
 set -e
 source /etc/os-release
+cidir=$(dirname "$0")
 start_test="$(date '+%Y-%m-%d %H:%M:%S')"
 last_test="${start_test}"
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -52,3 +52,11 @@ fi
 # see https://github.com/clearcontainers/runtime/issues/902
 last_test=$(date '+%Y-%m-%d %H:%M:%S')
 sudo -E PATH="$PATH" bash -c "make swarm"
+
+last_test=$(date '+%Y-%m-%d %H:%M:%S')
+#TODO <carlos>: cri-o and k8s are in 1.9
+#If install cri-containerd will upgrade crictl to 1.10 and will break k8s/kubaadm.
+#Lets install an run the test after run k8s tests
+echo "Install cri-containerd"
+bash -f ${cidir}/install_cri_containerd.sh
+sudo -E PATH="$PATH" bash -c "make cri-containerd"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -38,6 +38,10 @@ if [ -n "$PULL_REQUEST_NUMBER" ] || [ -n "$LOCALCI_PR_NUMBER" ]; then
 	bash -f "${cidir}/run_fetch_branches_tool.sh"
 fi
 
+echo "Install go"
+#TODO carlos need to build cri-containerd
+bash -f ${cidir}/install_go.sh 1.10
+
 
 echo "Install shim"
 bash -f ${cidir}/install_shim.sh
@@ -63,6 +67,9 @@ bash -f ${cidir}/install_crio.sh
 bash -f "${cidir}/install_kubernetes.sh"
 
 bash -f "${cidir}/openshift_setup.sh"
+
+echo "Install cri-containerd"
+bash -f ${cidir}/install_cri_containerd.sh
 
 echo "Drop caches"
 sync

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -68,9 +68,6 @@ bash -f "${cidir}/install_kubernetes.sh"
 
 bash -f "${cidir}/openshift_setup.sh"
 
-echo "Install cri-containerd"
-bash -f ${cidir}/install_cri_containerd.sh
-
 echo "Drop caches"
 sync
 sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -56,3 +56,6 @@ chronic sudo -E dnf -y install bison
 if ! command -v docker > /dev/null; then
 	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
 fi
+
+echo "Install cri-containerd dependencies"
+chronic sudo -E dnf -y install libseccomp-devel btrfs-progs-devel libseccomp-static

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -58,6 +58,9 @@ sudo -E apt install -y build-essential python pkg-config zlib1g-dev
 echo -e "Install CRI-O dependencies available for Ubuntu $VERSION_ID"
 sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux
 
+echo -e "Install cri-containerd dependencies available for Ubuntu $VERSION_ID"
+sudo -E apt install -y libseccomp-dev libapparmor-dev btrfs-tools
+
 if [ "$VERSION_ID" == "16.04" ]; then
 	echo "Install os-tree"
 	sudo -E add-apt-repository ppa:alexlarsson/flatpak -y

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ swarm:
 conformance:
 	bats conformance/posixfs/fstest.bats
 
-check: functional crio  integration conformance kubernetes cri-containerd
+check: functional crio integration conformance kubernetes
 
 all: functional checkcommits integration
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ crio:
 	bash .ci/install_bats.sh
 	RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh
 
+cri-containerd:
+	bash integration/containerd/cri/integration-tests.sh
+
 ginkgo:
 	ln -sf . vendor/src
 	GOPATH=$(PWD)/vendor go build ./vendor/github.com/onsi/ginkgo/ginkgo
@@ -52,7 +55,7 @@ swarm:
 conformance:
 	bats conformance/posixfs/fstest.bats
 
-check: functional crio integration conformance kubernetes
+check: functional crio  integration conformance kubernetes cri-containerd
 
 all: functional checkcommits integration
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -50,6 +50,10 @@ err_report() {
 trap err_report ERR
 trap cleanup EXIT
 
+info "Stop crio service"
+
+sudo systemctl stop crio
+
 info "testing using runtime: ${runtime_bin}"
 
 # make sure cri-containerd test install the proper installation for testing

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# 
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eE
+
+# Runtime to be used for testing.
+RUNTIME=${RUNTIME:-cc-runtime}
+# Variable to change project to test (eg. kata or clear-contaienrs)
+PROJECT_ORG="${PROJECT:-clear-containers}"
+readonly runtime_bin=$(command -v "${RUNTIME}")
+
+#cri-containerd configuration test variables
+CRITEST=${GOPATH}/bin/critest
+readonly tmp_dir=$(mktemp -t -d test-cri-containerd.XXXX)
+export REPORT_DIR="${tmp_dir}"
+
+
+info() {
+	echo -e "\e[1mINFO\e[0m: $*"
+}
+
+
+cleanup() {
+	rm -rf "${tmp_dir}"
+}
+
+err_report() {
+	echo "ERROR: contaienrd log :"
+	echo "-------------------------------------"
+	cat "${REPORT_DIR}/containerd.log"
+	echo "-------------------------------------"
+}
+
+trap err_report ERR
+trap cleanup EXIT
+
+info "testing using runtime: ${runtime_bin}"
+
+# make sure cri-containerd test install the proper installation for testing
+rm -f "${CRITEST}"
+
+
+cri_containerd_repo="github.com/containerd/cri"
+
+pushd "${GOPATH}/src/${cri_containerd_repo}"
+
+info "Starting test for cri-tools"
+sudo -E PATH="${PATH}" \
+	FOCUS="runtime should support basic operations on container" \
+	REPORT_DIR="${REPORT_DIR}" \
+	make test-cri
+
+info "Starting test for test-integration"
+sudo -E PATH="${PATH}" FOCUS="${t}"\
+	make test-integration
+popd
+


### PR DESCRIPTION
This PR adds tests to run `cc-runtime` as default runtime with `cri-containerd`

- ci: Add scripts to install cri-containerd
_Note: I added  the installation in `.ci/run.sh`, If install before run kueberentes test, k8s tests are going to fail. It is need to move our CI to k8s 1.10 first_

- Added new tests target to test only cri-containerd `make cri-containerd`
1. Added test-cri (critools) 
2. Added test-integration(cri-containerd integration tests.)